### PR TITLE
prevent detect user proxy when user model not persisted

### DIFF
--- a/lib/intercom-rails/proxy/user.rb
+++ b/lib/intercom-rails/proxy/user.rb
@@ -35,7 +35,7 @@ module IntercomRails
       end
 
       def valid?
-        return false if user.blank?
+        return false if user.blank? || user.new_record?
         return true if user.respond_to?(:id) && user.id.present?
         return true if user.respond_to?(:email) && user.email.present?
         false


### PR DESCRIPTION
Devise controller creates @user for a new session view 
