### PR TITLE
Fix error uninitialized constant IntercomRails::Import::ActiveRecord

### DIFF
--- a/lib/intercom-rails/import.rb
+++ b/lib/intercom-rails/import.rb
@@ -37,7 +37,7 @@ module IntercomRails
       raise ImportError, "You can only import your users from your production environment" unless Rails.env.production?
       raise ImportError, "We couldn't find your user class, please set one in config/initializers/intercom_rails.rb" unless user_klass.present?
       info "Found user class: #{user_klass}"
-      raise ImportError, "Only ActiveRecord models are supported" unless (user_klass < ActiveRecord::Base)
+      raise ImportError, "Only ActiveRecord models are supported" unless defined?(ActiveRecord::Base) && (user_klass < ActiveRecord::Base)
       raise ImportError, "Please add an Intercom API Key to config/initializers/intercom.rb" unless IntercomRails.config.api_key.present?
       info "Intercom API key found"
     end


### PR DESCRIPTION
The error is raised when ActiveRecord is not loaded in the Rails application, for example because using Mongoid or other ORM.
