### PR TITLE
Update timestamp generation to support ActiveSupport::TimeWithZone

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     tilt (1.3.3)
+    tzinfo (0.3.37)
 
 PLATFORMS
   ruby
@@ -72,3 +73,4 @@ DEPENDENCIES
   rspec-mocks
   sinatra (~> 1.3.1)
   thin (~> 1.4.1)
+  tzinfo

--- a/intercom-rails.gemspec
+++ b/intercom-rails.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'sinatra', '~> 1.3.1'
   s.add_development_dependency 'thin', '~> 1.4.1'
+  s.add_development_dependency 'tzinfo'
 end

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -112,7 +112,7 @@ module IntercomRails
 
     def convert_dates_to_unix_timestamps(object)
       return Hash[object.map { |k, v| [k, convert_dates_to_unix_timestamps(v)] }] if object.is_a?(Hash)
-      return object.strftime('%s').to_i if object.respond_to?(:strftime)
+      return object.to_i if object.is_a?(Time) || object.is_a?(DateTime)
       object
     end
 

--- a/test/intercom-rails/script_tag_test.rb
+++ b/test/intercom-rails/script_tag_test.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string/output_safety'
+require 'active_support/time'
 require 'test_setup'
 
 class ScriptTagTest < MiniTest::Unit::TestCase
@@ -23,6 +24,12 @@ class ScriptTagTest < MiniTest::Unit::TestCase
     now = Time.now
     nested_time = ScriptTag.new(:user_details => {:custom_data => {"something" => now}})
     assert_equal now.to_i, nested_time.intercom_settings[:custom_data]["something"]
+
+    utc_time = Time.utc(2013,04,03)
+    time_zone = ActiveSupport::TimeZone.new('London')
+    time_with_zone = ActiveSupport::TimeWithZone.new(utc_time, time_zone)
+    time_from_time_with_zone = ScriptTag.new(:user_details => {:created_at => time_with_zone})
+    assert_equal utc_time.to_i, time_from_time_with_zone.intercom_settings[:created_at]
   end
 
   def test_strips_out_nil_entries_for_standard_attributes


### PR DESCRIPTION
We found that the current method for generating unix timestamps in `ScriptTag` can produce the wrong timestamp for `ActiveSupport::TimeWithZone` objects.

It seems that `TimeWithZone#strftime('%s')` will yield a timestamp that includes daylight savings offsets. The resulting timestamp will be an hour adrift if daylight savings are in effect.

This PR switches to using `to_i` directly on `Time`, `DateTime` and their descendants.
