### PR TITLE
By default, enable only in production env

### DIFF
--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -1,7 +1,7 @@
 IntercomRails.config do |config|
   # == Intercom app_id
   # 
-  config.app_id = ENV["INTERCOM_APP_ID"] || "<%= @app_id %>"
+  config.app_id = ENV["INTERCOM_APP_ID"] || "<%= @app_id %>" if Rails.env.production?
 
   # == Intercom secret key 
   # This is required to enable secure mode, you can find it on your Intercom 


### PR DESCRIPTION
After moving from a custom partial to the `intercom-rails` JS insertion, many test accounts were appearing in my daily signup emails. It turns out the config generator currently enables the app_id for all environments.

This edit changes to only enable in production env, which seems a more sensible default.
