### PR TITLE
Developers can set environments for automatic javascript insertion

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -29,6 +29,7 @@ module IntercomRails
       end
 
       def include_javascript?
+        is_enabled_for_environment? &&
         !intercom_script_tag_called_manually? &&
         html_content_type? &&
         response_has_closing_body_tag? &&
@@ -54,6 +55,10 @@ module IntercomRails
 
       def intercom_script_tag
         @script_tag ||= ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller)
+      end
+
+      def is_enabled_for_environment?
+        IntercomRails.config.environments_enabled_for.include?(Rails.env)
       end
 
     end

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -60,6 +60,10 @@ module IntercomRails
       end
     end
 
+    ARRAY_VALIDATOR = Proc.new do |data, field_name|
+      raise ArgumentError, "#{field_name} data should be an Array" unless data.kind_of?(Array)
+    end
+
     IS_PROC_VALIDATOR = Proc.new do |value, field_name|
       raise ArgumentError, "#{field_name} is not a proc" unless value.kind_of?(Proc)
     end
@@ -79,6 +83,7 @@ module IntercomRails
     config_accessor :api_secret
     config_accessor :api_key
     config_accessor :library_url
+    config_accessor :environments_enabled_for, &ARRAY_VALIDATOR
 
     config_group :user do
       config_accessor :current, &IS_PROC_VALIDATOR 

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -23,6 +23,11 @@ IntercomRails.config do |config|
   # config.api_key = "..."
   <%- end -%>
 
+  # == Environments Enabled For
+  # Define which rails environments you would like automatic insertion of Intercom
+  #
+  config.environments_enabled_for = ["development", "production"]
+
   # == Curent user name
   # The method/variable that contains the logged in user in your controllers.
   # If it is `current_user` or `@user`, then you can ignore this


### PR DESCRIPTION
I know there is another pull request (intercom/intercom-rails#41) to force only js insertion in production but that would break the intercom sign up flow, so I worked on this alternative.

I eventually went with string names in the config and calling Rails.env from within the filter callback. I had noticed that there wasn't any other references to Rails but thought it would be ok considering this is a gem for Rails only.

Also in the tests I couldn't figure out a neater way to set the Rails.env - happy to change to something else.
