### PR TITLE
Fallback for unset environment

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -58,7 +58,11 @@ module IntercomRails
       end
 
       def enabled_for_environment?
-        IntercomRails.config.enabled_environments.include?(Rails.env)
+        if IntercomRails.config.enabled_environments
+          IntercomRails.config.enabled_environments.include?(Rails.env)
+        else
+          return true
+        end
       end
 
     end


### PR DESCRIPTION
The latest pull request from @kalv for setting environments is great. However, those upgrading from a previous version of the gem get a fatal error for not having config.enabled_environments set. I included a fallback so those upgrading the gem can continue business as normal. 
