### PR TITLE
Adds ability to import in a staging environment

### DIFF
--- a/lib/intercom-rails/import.rb
+++ b/lib/intercom-rails/import.rb
@@ -48,7 +48,7 @@ module IntercomRails
     end
 
     def assert_runnable
-      raise ImportError, "You can only import your users from your production environment" unless Rails.env.production?
+      raise ImportError, "You can only import your users from your production environment" unless (Rails.env.production? || Rails.env.staging?)
       raise ImportError, "We couldn't find your user class, please set one in config/initializers/intercom_rails.rb" unless user_klass.present?
       info "Found user class: #{user_klass}"
       raise ImportError, "Only ActiveRecord and Mongoid models are supported" unless supported_orm?(user_klass)


### PR DESCRIPTION
This seems a trivial PR since most people's staging environment is actually a production environment, but just in-case some one does the right thing and runs their staging environment with `RAILS_ENV=staging` the gem shouldn't block them.
