### PR TITLE
Include last_seen_ip and last_request on import

### DIFF
--- a/lib/intercom-rails/import.rb
+++ b/lib/intercom-rails/import.rb
@@ -100,6 +100,9 @@ module IntercomRails
         user_proxy = Proxy::User.new(u)
         next unless user_proxy.valid?
 
+        user_proxy.class.proxy_delegator :last_seen_ip
+        user_proxy.class.proxy_delegator :last_request_at
+
         for_wire = user_proxy.to_hash
         companies = Proxy::Company.companies_for_user(user_proxy)
         for_wire.merge!(:companies => companies.map(&:to_hash)) if companies.present?


### PR DESCRIPTION
If the user object knows about last IP/request, it is useful to include
this information when importing existing users.

This was very important for me - don't know if this is useful in general. 
