### PR TITLE
Add ability to supply Proc/Symbol for custom_data

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -54,9 +54,14 @@ module IntercomRails
   class Config < ConfigSingleton
 
     CUSTOM_DATA_VALIDATOR = Proc.new do |custom_data, field_name|
-      raise ArgumentError, "#{field_name} custom_data should be a hash" unless custom_data.kind_of?(Hash)
-      unless custom_data.values.all? { |value| value.kind_of?(Proc) || value.kind_of?(Symbol) }
-        raise ArgumentError, "all custom_data attributes should be either a Proc or a symbol"
+      case custom_data
+      when Hash
+        unless custom_data.values.all? { |value| value.kind_of?(Proc) || value.kind_of?(Symbol) }
+          raise ArgumentError, "all custom_data attributes should be either a Proc or a symbol"
+        end
+      when Proc, Symbol
+      else
+        raise ArgumentError, "#{field_name} custom_data should be either be a hash or a Proc/Symbol that returns a hash when called"
       end
     end
 

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -21,13 +21,7 @@ module IntercomRails
 
     def self.config_writer(name, &block)
       meta_class.send(:define_method, "#{name}=") do |value|
-        block.call(value) if block && (block.arity <= 1)
-
-        if block && (block.arity > 1)
-          field_name = underscored_class_name ? "#{underscored_class_name}.#{name}" : name
-          block.call(value, field_name) 
-        end
-
+        validate(name, value, block)
         instance_variable_set("@#{name}", value)
       end
     end
@@ -45,6 +39,17 @@ module IntercomRails
     end
 
     private
+
+    def self.validate(name, value, block)
+      return unless block
+      args = [value]
+      if block.arity > 1
+        field_name = underscored_class_name ? "#{underscored_class_name}.#{name}" : name
+        args << field_name
+      end
+      block.call(*args)
+    end
+
     def self.underscored_class_name
       @underscored_class_name
     end

--- a/lib/intercom-rails/proxy.rb
+++ b/lib/intercom-rails/proxy.rb
@@ -124,16 +124,19 @@ module IntercomRails
 
       def custom_data_from_config 
         return {} if config.custom_data.blank?
-        config.custom_data.reduce({}) do |custom_data, (k,v)|
-          custom_data.merge(k => custom_data_value_from_proc_or_symbol(v))
-        end
+        custom_data_value(config.custom_data)
       end
 
-      def custom_data_value_from_proc_or_symbol(proc_or_symbol)
-        if proc_or_symbol.kind_of?(Symbol)
-          proxied_object.send(proc_or_symbol)
-        elsif proc_or_symbol.kind_of?(Proc)
-          proc_or_symbol.call(proxied_object)
+      def custom_data_value(proc_or_symbol_or_hash)
+        case proc_or_symbol_or_hash
+        when Symbol
+          proxied_object.send(proc_or_symbol_or_hash)
+        when Proc
+          proc_or_symbol_or_hash.call(proxied_object)
+        when Hash
+          proc_or_symbol_or_hash.reduce({}) do |custom_data, (k,v)|
+            custom_data.merge(k => custom_data_value(v))
+          end
         end
       end
 

--- a/test/intercom-rails/config_test.rb
+++ b/test/intercom-rails/config_test.rb
@@ -29,6 +29,14 @@ class ConfigTest < MiniTest::Unit::TestCase
     assert_equal IntercomRails.config.app_id, "4567"
   end
 
+  def test_custom_data_rejects_non_proc_non_symbol_non_hash_value
+    exception = assert_raises ArgumentError do
+      IntercomRails.config.user.custom_data = 'foo'
+    end
+
+    assert_equal "custom_data custom_data should be either be a hash or a Proc/Symbol that returns a hash when called", exception.message
+  end
+
   def test_custom_data_rejects_non_proc_or_symbol_attributes
     exception = assert_raises ArgumentError do 
       IntercomRails.config.user.custom_data = {
@@ -38,6 +46,17 @@ class ConfigTest < MiniTest::Unit::TestCase
     end 
 
     assert_equal "all custom_data attributes should be either a Proc or a symbol", exception.message
+  end
+
+  def test_setting_custom_data_with_proc
+    custom_data = {
+      'foo' => 'bar',
+      'bar' => 'baz'
+    }
+    custom_data_config = Proc.new { custom_data }
+
+    IntercomRails.config.user.custom_data = custom_data_config
+    assert_equal custom_data, IntercomRails.config.user.custom_data.call
   end
 
   def test_setting_custom_data

--- a/test/intercom-rails/proxy/user_test.rb
+++ b/test/intercom-rails/proxy/user_test.rb
@@ -82,6 +82,40 @@ class UserTest < MiniTest::Unit::TestCase
     assert_equal 'pro', @user_proxy.to_hash['plan']
   end
 
+  def test_can_work_with_proc_custom_data
+    plan_dummy_user = DUMMY_USER.dup
+    plan_dummy_user.instance_eval do
+      def custom_data
+        {
+          'plan' => 'pro',
+          'registered_at' => Time.at(5),
+        }
+      end
+    end
+
+    IntercomRails.config.user.custom_data = Proc.new { |u| u.custom_data }
+
+    @user_proxy = User.new(plan_dummy_user)
+    assert_equal 'pro', @user_proxy.to_hash['plan']
+  end
+
+  def test_can_work_with_symbol_custom_data
+    plan_dummy_user = DUMMY_USER.dup
+    plan_dummy_user.instance_eval do
+      def custom_data
+        {
+          'plan' => 'pro',
+          'registered_at' => Time.at(5),
+        }
+      end
+    end
+
+    IntercomRails.config.user.custom_data = :custom_data
+
+    @user_proxy = User.new(plan_dummy_user)
+    assert_equal 'pro', @user_proxy.to_hash['plan']
+  end
+
   def test_converts_dates_to_timestamps
     plan_dummy_user = DUMMY_USER.dup
     plan_dummy_user.instance_eval do


### PR DESCRIPTION
It is sometimes the case that different `custom_data` attribute values are
related to each other and for better performance should be fetched
together. However, the current way of supplying a `Hash` with `Proc`/`Symbol`
values prevents these types of optimizations.

The current patch enables library users to supply a `Proc` or a `Symbol`,
that returns a `Hash`, for the whole `custom_data` attribute. This way, all
`custom_data` that belongs to a single user can be generated in one `Proc`
call. Even better, `custom_data` generation can be turned into a
method on the `User` model if a `Symbol` is supplied.

**Note:** Added tests to ensure new functionality works as intended. I'd be more than happy to add any other tests that you see appropriate.