### PR TITLE
Remove trailing spaces

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -21,10 +21,10 @@ module IntercomRails
       attr_reader :controller
 
       def initialize(kontroller)
-        @controller = kontroller 
+        @controller = kontroller
       end
 
-      def include_javascript! 
+      def include_javascript!
         response.body = response.body.gsub(CLOSING_BODY_TAG, intercom_script_tag.output + '\\0')
       end
 

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -2,7 +2,7 @@ require 'active_support/inflector'
 
 module IntercomRails
 
-  class ConfigSingleton 
+  class ConfigSingleton
 
     def self.config_accessor(*args, &block)
       config_reader(*args)
@@ -25,7 +25,7 @@ module IntercomRails
 
         if block && (block.arity > 1)
           field_name = underscored_class_name ? "#{underscored_class_name}.#{name}" : name
-          block.call(value, field_name) 
+          block.call(value, field_name)
         end
 
         instance_variable_set("@#{name}", value)
@@ -78,7 +78,7 @@ module IntercomRails
         end
       end
     end
- 
+
     config_accessor :app_id
     config_accessor :api_secret
     config_accessor :api_key
@@ -86,15 +86,15 @@ module IntercomRails
     config_accessor :enabled_environments, &ARRAY_VALIDATOR
 
     config_group :user do
-      config_accessor :current, &IS_PROC_VALIDATOR 
+      config_accessor :current, &IS_PROC_VALIDATOR
       config_accessor :model, &IS_PROC_VALIDATOR
       config_accessor :company_association, &IS_PROC_VALIDATOR
       config_accessor :custom_data, &CUSTOM_DATA_VALIDATOR
     end
-    
+
     config_group :company do
       config_accessor :current, &IS_PROC_VALIDATOR
-      config_accessor :plan, &IS_PROC_VALIDATOR 
+      config_accessor :plan, &IS_PROC_VALIDATOR
       config_accessor :monthly_spend, &IS_PROC_VALIDATOR
       config_accessor :custom_data, &CUSTOM_DATA_VALIDATOR
     end

--- a/lib/intercom-rails/custom_data_helper.rb
+++ b/lib/intercom-rails/custom_data_helper.rb
@@ -1,7 +1,7 @@
 module IntercomRails
 
   module CustomDataHelper
-    
+
     # This helper allows custom data attributes to be added to a user
     # for the current request from within the controller. e.g.
     #

--- a/lib/intercom-rails/import.rb
+++ b/lib/intercom-rails/import.rb
@@ -28,7 +28,7 @@ module IntercomRails
       @status_enabled = !!options[:status_enabled]
 
       if uri.scheme == 'https'
-        http.use_ssl = true 
+        http.use_ssl = true
         http.ca_file = File.join(File.dirname(__FILE__), '../data/cacert.pem')
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       end
@@ -70,7 +70,7 @@ module IntercomRails
       end
       info "Successfully created #{self.total_sent - self.failed.count} users", :new_line => true
       info "Failed to create #{self.failed.count} #{(self.failed.count == 1) ? 'user' : 'users'}, this is likely due to bad data" unless failed.count.zero?
-      
+
       self
     end
 
@@ -119,15 +119,15 @@ module IntercomRails
         User
       end
     rescue NameError
-      # Rails lazy loads constants, so this is how we check 
+      # Rails lazy loads constants, so this is how we check
       nil
     end
 
     def send_users(users)
-      request = Net::HTTP::Post.new(uri.request_uri) 
+      request = Net::HTTP::Post.new(uri.request_uri)
       request.basic_auth(IntercomRails.config.app_id, IntercomRails.config.api_key)
       request["Content-Type"] = "application/json"
-      request.body = users 
+      request.body = users
 
       response = perform_request(request)
       JSON.parse(response.body)
@@ -136,7 +136,7 @@ module IntercomRails
     MAX_REQUEST_ATTEMPTS = 3
     def perform_request(request, attempts = 0, error = {})
       if (attempts > 0) && (attempts < MAX_REQUEST_ATTEMPTS)
-        sleep(0.5) 
+        sleep(0.5)
       elsif error.present?
         raise error[:exception] if error[:exception]
         raise exception_for_failed_response(error[:failed_response])

--- a/lib/intercom-rails/proxy.rb
+++ b/lib/intercom-rails/proxy.rb
@@ -10,7 +10,7 @@ module IntercomRails
 
       def self.inherited(subclass)
         subclass.class_eval do
-          attr_reader class_string.downcase.to_s 
+          attr_reader class_string.downcase.to_s
         end
       end
 
@@ -76,7 +76,7 @@ module IntercomRails
         identity_attributes << attribute_name if options[:identity]
 
         send(:define_method, attribute_name) do
-          return nil unless proxied_object.respond_to?(attribute_name) 
+          return nil unless proxied_object.respond_to?(attribute_name)
 
           current_value = instance_variable_get(instance_variable_name)
           return current_value if current_value
@@ -116,13 +116,13 @@ module IntercomRails
 
       private
 
-      def custom_data_from_request 
+      def custom_data_from_request
         search_object.intercom_custom_data.send(type)
       rescue NoMethodError
         {}
       end
 
-      def custom_data_from_config 
+      def custom_data_from_config
         return {} if config.custom_data.blank?
         config.custom_data.reduce({}) do |custom_data, (k,v)|
           custom_data.merge(k => custom_data_value_from_proc_or_symbol(v))

--- a/lib/intercom-rails/proxy/company.rb
+++ b/lib/intercom-rails/proxy/company.rb
@@ -22,17 +22,17 @@ module IntercomRails
       def self.current_in_context(search_object)
         begin
           if config.current.present?
-            company_proxy = new(search_object.instance_eval(&config.current), search_object) 
+            company_proxy = new(search_object.instance_eval(&config.current), search_object)
             return company_proxy if company_proxy.valid?
           end
         rescue NameError
         end
 
-        raise NoCompanyFoundError 
+        raise NoCompanyFoundError
       end
 
       def valid?
-        company.present? && identity_present? 
+        company.present? && identity_present?
       end
 
     end

--- a/lib/intercom-rails/script_tag_helper.rb
+++ b/lib/intercom-rails/script_tag_helper.rb
@@ -3,7 +3,7 @@ module IntercomRails
 
   module ScriptTagHelper
     # Generate an intercom script tag.
-    # 
+    #
     # @param user_details [Hash] a customizable hash of user details
     # @param options [Hash] an optional hash for secure mode and widget customisation
     # @option user_details [String] :app_id Your application id
@@ -12,7 +12,7 @@ module IntercomRails
     # @option user_details [String] :name the users name, _optional_ but useful for identify people in the Intercom App.
     # @option user_details [Hash] :custom_data custom attributes you'd like saved for this user on Intercom.
     # @option options [String] :widget a hash containing a css selector for an element which when clicked should show the Intercom widget
-    # @option options [String] :secret Your app secret for secure mode 
+    # @option options [String] :secret Your app secret for secure mode
     # @return [String] Intercom script tag
     # @example basic example
     #   <%= intercom_script_tag({ :app_id => "your-app-id",

--- a/lib/rails/generators/intercom/config/config_generator.rb
+++ b/lib/rails/generators/intercom/config/config_generator.rb
@@ -17,7 +17,7 @@ module Intercom
         @api_key = api_key
 
         introduction = <<-desc
-Intercom will automatically insert its javascript before the closing '</body>' 
+Intercom will automatically insert its javascript before the closing '</body>'
 tag on every page where it can find a logged-in user. Intercom by default
 looks for logged-in users, in the controller, via 'current_user' and '@user'.
 
@@ -25,9 +25,9 @@ Is the logged-in user accessible via either 'current_user' or '@user'? [Yn]
         desc
 
         print "#{introduction.strip} "
-        default_ok = $stdin.gets.strip.downcase 
+        default_ok = $stdin.gets.strip.downcase
 
-        if FALSEY_RESPONSES.include?(default_ok) 
+        if FALSEY_RESPONSES.include?(default_ok)
           custom_current_user_question = <<-desc
 
 How do you access the logged-in user in your controllers? This can be

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -1,12 +1,12 @@
 IntercomRails.config do |config|
   # == Intercom app_id
-  # 
+  #
   config.app_id = ENV["INTERCOM_APP_ID"] || "<%= @app_id %>"
 
-  # == Intercom secret key 
-  # This is required to enable secure mode, you can find it on your Intercom 
+  # == Intercom secret key
+  # This is required to enable secure mode, you can find it on your Intercom
   # "security" configuration page.
-  # 
+  #
   <%- if @api_secret -%>
   config.api_secret = "<%= @api_secret %>"
   <%- else -%>
@@ -37,7 +37,7 @@ IntercomRails.config do |config|
   <%- else -%>
   # config.user.current = Proc.new { current_user }
   <%- end -%>
-  
+
   # == User model class
   # The class which defines your user model
   #
@@ -56,13 +56,13 @@ IntercomRails.config do |config|
   # == User -> Company association
   # A Proc that given a user returns an array of companies
   # that the user belongs to.
-  # 
+  #
   # config.user.company_association = Proc.new { |user| user.companies.to_a }
   # config.user.company_association = Proc.new { |user| [user.company] }
 
   # == Current company method/variable
   # The method/variable that contains the current company for the current user,
-  # in your controllers. 'Companies' are generic groupings of users, so this 
+  # in your controllers. 'Companies' are generic groupings of users, so this
   # could be a company, app or group.
   #
   # config.company.current = Proc.new { current_company }
@@ -79,7 +79,7 @@ IntercomRails.config do |config|
   # == Company Plan name
   # This is the name of the plan a company is currently paying (or not paying) for.
   # e.g. Messaging, Free, Pro, etc.
-  #  
+  #
   # config.company.plan = Proc.new { |current_company| current_company.plan.name }
 
   # == Company Monthly Spend
@@ -88,15 +88,15 @@ IntercomRails.config do |config|
   #
   # config.company.monthly_spend = Proc.new { |current_company| current_company.plan.price }
   # config.company.monthly_spend = Proc.new { |current_company| (current_company.plan.price - current_company.subscription.discount) }
- 
+
   # == Inbox Style
   # This enables the Intercom inbox which allows your users to read their
-  # past conversations with your app, as well as start new ones. It is 
+  # past conversations with your app, as well as start new ones. It is
   # disabled by default.
   #   * :default shows a small tab with a question mark icon on it
   #   * :custom attaches the inbox open event to an anchor with an
   #             id of #Intercom.
   #
-  # config.inbox.style = :default 
+  # config.inbox.style = :default
   # config.inbox.style = :custom
 end

--- a/test/action_controller_test_setup.rb
+++ b/test/action_controller_test_setup.rb
@@ -25,5 +25,5 @@ class ActionController::TestCase
     super
     @routes = TestRoutes
   end
-  
+
 end

--- a/test/import_test_setup.rb
+++ b/test/import_test_setup.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 end
 
 module Mongoid
-  module Document 
+  module Document
     def self.included(klass)
       klass.extend ClassMethods
     end

--- a/test/intercom-rails/auto_include_filter_test.rb
+++ b/test/intercom-rails/auto_include_filter_test.rb
@@ -4,7 +4,7 @@ class TestController < ActionController::Base
 
   skip_after_filter :intercom_rails_auto_include, :only => :with_user_instance_variable_after_filter_skipped
 
-  def without_user 
+  def without_user
     render :text => params[:body], :content_type => 'text/html'
   end
 
@@ -22,10 +22,10 @@ class TestController < ActionController::Base
     @app = dummy_company
     render :text => params[:body], :content_type => 'text/html'
   end
-  
+
   def with_user_instance_variable_and_custom_data
     @user = dummy_user
-    intercom_custom_data.user['testing_stuff'] = true 
+    intercom_custom_data.user['testing_stuff'] = true
     render :text => params[:body], :content_type => 'text/html'
   end
 
@@ -50,7 +50,7 @@ class TestController < ActionController::Base
 
 end
 
-class AutoIncludeFilterTest < ActionController::TestCase 
+class AutoIncludeFilterTest < ActionController::TestCase
 
   include InterTest
 
@@ -64,7 +64,7 @@ class AutoIncludeFilterTest < ActionController::TestCase
   def teardown
     IntercomRails.config.app_id = nil
   end
-  
+
   def test_no_user_present
     get :without_user, :body => "<body>Hello world</body>"
     assert_equal @response.body, "<body>Hello world</body>"
@@ -84,7 +84,7 @@ class AutoIncludeFilterTest < ActionController::TestCase
     get :with_user_instance_variable, :body => "<body>Hello world</body>"
 
     assert_includes @response.body, "<script>"
-    assert_includes @response.body, IntercomRails.config.app_id 
+    assert_includes @response.body, IntercomRails.config.app_id
     assert_includes @response.body, "ben@intercom.io"
     assert_includes @response.body, "Ben McRedmond"
   end

--- a/test/intercom-rails/config_test.rb
+++ b/test/intercom-rails/config_test.rb
@@ -1,6 +1,6 @@
 require 'test_setup'
 
-class ConfigTest < MiniTest::Unit::TestCase 
+class ConfigTest < MiniTest::Unit::TestCase
 
   include InterTest
 
@@ -30,12 +30,12 @@ class ConfigTest < MiniTest::Unit::TestCase
   end
 
   def test_custom_data_rejects_non_proc_or_symbol_attributes
-    exception = assert_raises ArgumentError do 
+    exception = assert_raises ArgumentError do
       IntercomRails.config.user.custom_data = {
         'foo' => Proc.new {},
         'bar' => 'heyheyhey!'
       }
-    end 
+    end
 
     assert_equal "all custom_data attributes should be either a Proc or a symbol", exception.message
   end

--- a/test/intercom-rails/import_network_test.rb
+++ b/test/intercom-rails/import_network_test.rb
@@ -15,7 +15,7 @@ class MockIntercom < Sinatra::Base
   end
 
   post '/all_successful' do
-    {:failed => []}.to_json 
+    {:failed => []}.to_json
   end
 
   post '/one_failure' do
@@ -37,7 +37,7 @@ end
 class InterRunner < MiniTest::Unit
 
   self.runner = self.new
-  
+
   def _run(*args)
     @mock_intercom_pid = start_mock_intercom
     super
@@ -49,7 +49,7 @@ class InterRunner < MiniTest::Unit
   private
 
   def start_mock_intercom
-    pid = fork do 
+    pid = fork do
       MockIntercom.run!(:port => 46837) do |server|
         server.silent = true
       end
@@ -102,7 +102,7 @@ class ImportNetworkTest < InterRunner::TestCase
   def test_raises_import_error_on_bad_auth
     self.api_path = '/bad_auth'
 
-    exception = assert_raises(IntercomRails::ImportError) { 
+    exception = assert_raises(IntercomRails::ImportError) {
       @import.run
     }
 

--- a/test/intercom-rails/import_unit_test.rb
+++ b/test/intercom-rails/import_unit_test.rb
@@ -1,6 +1,6 @@
 require 'import_test_setup'
 
-class ImportUnitTest < MiniTest::Unit::TestCase 
+class ImportUnitTest < MiniTest::Unit::TestCase
 
   include InterTest
   include ImportTest
@@ -21,7 +21,7 @@ class ImportUnitTest < MiniTest::Unit::TestCase
     exception = assert_raises IntercomRails::ImportError do
       IntercomRails::Import.run
     end
-    
+
     assert_equal exception.message, "We couldn't find your user class, please set one in config/initializers/intercom_rails.rb"
   end
 
@@ -31,7 +31,7 @@ class ImportUnitTest < MiniTest::Unit::TestCase
     exception = assert_raises IntercomRails::ImportError do
       IntercomRails::Import.run
     end
-    
+
     assert_equal exception.message, "Only ActiveRecord and Mongoid models are supported"
   end
 
@@ -41,7 +41,7 @@ class ImportUnitTest < MiniTest::Unit::TestCase
     exception = assert_raises IntercomRails::ImportError do
       IntercomRails::Import.run
     end
-    
+
     assert_equal exception.message, "Please add an Intercom API Key to config/initializers/intercom.rb"
   end
 

--- a/test/intercom-rails/proxy/company_test.rb
+++ b/test/intercom-rails/proxy/company_test.rb
@@ -9,7 +9,7 @@ class CompanyTest < MiniTest::Unit::TestCase
 
   def test_finds_current_company
     IntercomRails.config.company.current = Proc.new { @app }
-    object_with_app_instance_var = Object.new 
+    object_with_app_instance_var = Object.new
     object_with_app_instance_var.instance_variable_set(:@app, DUMMY_COMPANY)
 
     c = Company.current_in_context(object_with_app_instance_var)
@@ -25,7 +25,7 @@ class CompanyTest < MiniTest::Unit::TestCase
       end
     end
 
-    search_object = nil 
+    search_object = nil
     assert_equal false, Company.new(search_object).valid?
   end
 

--- a/test/intercom-rails/proxy/user_test.rb
+++ b/test/intercom-rails/proxy/user_test.rb
@@ -24,17 +24,17 @@ class UserTest < MiniTest::Unit::TestCase
     end
 
     @user_proxy = User.current_in_context(object_with_current_user_method)
-    assert_user_found 
+    assert_user_found
   end
 
   def test_finds_user_instance_variable
     object_with_instance_variable = Object.new
     object_with_instance_variable.instance_eval do
-      @user = DUMMY_USER 
+      @user = DUMMY_USER
     end
 
     @user_proxy = User.current_in_context(object_with_instance_variable)
-    assert_user_found 
+    assert_user_found
   end
 
   def test_finds_config_user
@@ -47,14 +47,14 @@ class UserTest < MiniTest::Unit::TestCase
 
     IntercomRails.config.user.current = Proc.new { something_esoteric }
     @user_proxy = User.current_in_context(object_from_config)
-    assert_user_found 
+    assert_user_found
   end
 
   def test_finds_config_user_does_not_fallback_to_auto_find_users
     IntercomRails.config.user.current = Proc.new { something_esoteric }
     object_with_instance_variable = Object.new
     object_with_instance_variable.instance_eval do
-      @user = DUMMY_USER 
+      @user = DUMMY_USER
     end
 
     assert_raises(IntercomRails::NoUserFoundError) {
@@ -114,18 +114,18 @@ class UserTest < MiniTest::Unit::TestCase
     object_with_intercom_custom_data = Object.new
     object_with_intercom_custom_data.instance_eval do
       def intercom_custom_data
-        o = Object.new 
-        o.instance_eval do 
+        o = Object.new
+        o.instance_eval do
           def user
             {:ponies => :rainbows}
           end
-        end 
+        end
 
         o
       end
     end
 
-    @user_proxy = User.new(DUMMY_USER, object_with_intercom_custom_data) 
+    @user_proxy = User.new(DUMMY_USER, object_with_intercom_custom_data)
     assert_equal :rainbows, @user_proxy.to_hash[:ponies]
   end
 
@@ -136,7 +136,7 @@ class UserTest < MiniTest::Unit::TestCase
       end
     end
 
-    search_object = nil 
+    search_object = nil
     assert_equal false, User.new(search_object).valid?
   end
 

--- a/test/intercom-rails/script_tag_test.rb
+++ b/test/intercom-rails/script_tag_test.rb
@@ -92,7 +92,7 @@ class ScriptTagTest < MiniTest::Unit::TestCase
     IntercomRails.config.company.current = Proc.new { @app }
     object_with_app_instance_variable = Object.new
     object_with_app_instance_variable.instance_eval do
-      @app = dummy_company 
+      @app = dummy_company
     end
 
     script_tag = ScriptTag.new(:controller => object_with_app_instance_variable,

--- a/test/test_setup.rb
+++ b/test/test_setup.rb
@@ -31,7 +31,7 @@ class Object
   def self.unstub_all_instance_methods
     public_instance_methods.each do |method|
       begin
-        self.any_instance.unstub(method) 
+        self.any_instance.unstub(method)
       rescue RSpec::Mocks::MockExpectationError
         next
       end


### PR DESCRIPTION
After running `rails generate intercom:config ...` command I noticed the generated file contains several trailing spaces, thought it would be nice to clean them up. :grin: 
