### PR TITLE
Fix link typo on readme

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -17,7 +17,7 @@ Then run:
 bundle install
 ```
 
-Take note of your `app_id` from [here](https://www.intercom.io/apps/api_keys) and generate a config file:
+Take note of your `app_id` from [here](https://app.intercom.io/apps/api_keys) and generate a config file:
 
 ```
 rails generate intercom:config YOUR-APP-ID


### PR DESCRIPTION
intercom probably changed the api_keys url to get your API keys
