### PR TITLE
Propose adding a license to match intercom-ruby

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2011- Intercom, Inc. (https://www.intercom.io)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.mdown
+++ b/README.mdown
@@ -23,7 +23,7 @@ Take note of your `app_id` from [here](https://app.intercom.io/apps/api_keys) an
 rails generate intercom:config YOUR-APP-ID
 ```
 
-To make installing Intercom as easy as possible, where possible a `<script>` tag **will be automatically inserted before the closing `</body>` tag**. For most Rails apps, **you won't need to do any extra config**. Having trouble? Check out troubleshooting below. 
+To make installing Intercom as easy as possible, where possible a `<script>` tag **will be automatically inserted before the closing `</body>` tag**. For most Rails apps, **you won't need to do any extra config**. Having trouble? Check out troubleshooting below.
 
 ### Disabling automatic insertion
 
@@ -56,13 +56,13 @@ If you want to use secure mode, ensure you set your API secret in `config/initia
 ```
 
 ### Custom Data
-Custom data lets you associate any data, specific to your app, with a user in Intercom. For custom data variables you want updated on every request set them in `config/initializers/intercom.rb`. 
+Custom data lets you associate any data, specific to your app, with a user in Intercom. For custom data variables you want updated on every request set them in `config/initializers/intercom.rb`.
 
 You can give either a:
 
   * `Proc` which will be passed the current user object
-  * Or, a method which will be sent to the current user object 
-  
+  * Or, a method which will be sent to the current user object
+
 to generate the values of the custom data:
 
 ```ruby
@@ -123,7 +123,7 @@ By default Intercom will be automatically inserted in development and production
   config.enabled_environments = ["production"]
 ```
 
-### Manually Inserting the Intercom Javascript 
+### Manually Inserting the Intercom Javascript
 
 Some situations may require manually inserting the Intercom script tag. If you simply wish to place the Intercom javascript in a different place within the page or, on a page without a closing `</body>` tag:
 
@@ -179,5 +179,9 @@ Any custom data defined in `config/initializers/intercom.rb` will also be sent.
 - Alexander Chaychuk (@sashich) - fixed bug in user detection when users not persisted (e.g. new session view with devise).
 
 ## License
+
+intercom-rails is released under the [MIT License](http://www.opensource.org/licenses/MIT).
+
+## Copyright
 
 Copyright (c) 2011-2012 Intercom, Inc.  All rights reserved.


### PR DESCRIPTION
This PR adds a copy of the license file from https://github.com/intercom/intercom-ruby to the intercom-rails repo. The gem currently has a copyright assertion in place of a license, and this lack of license makes it difficult for companies to use the gem.
