### PR TITLE
fix for user_id/id for mongo/mongoid documents being serialized as {:oid...

### DIFF
--- a/lib/intercom-rails/proxy.rb
+++ b/lib/intercom-rails/proxy.rb
@@ -23,6 +23,11 @@ module IntercomRails
 
       def to_hash
         data = standard_data.merge(custom_data)
+        [:id, :user_id].each do |id_key|
+          if(data[id_key] && !data[id_key].is_a?(Numeric))
+            data[id_key] = data[id_key].to_s
+          end
+        end
         DateHelper.convert_dates_to_unix_timestamps(data)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,18 @@ def dummy_user(options = {})
   user
 end
 
+class DummyBSONId
+  def initialize(id)
+    @id = id
+  end
+  def as_json(_)
+    {:oid => @id}
+  end
+  def to_s
+    @id
+  end
+end
+
 def dummy_company(options = {})
   company = Struct.new(:id, :name).new
   company.id = options[:id] || '6'


### PR DESCRIPTION
... => 'abc123'}, attempting to not change behavior for existing numeric id's - to address #42

cc @eoin @benmcredmond
