### PR TITLE
Update docs to account for default messenger button behaviour

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -115,28 +115,22 @@ config.company.custom_data = {
 }
 ```
 
-### Inbox
-Intercom includes an inbox which allows a user to read their past conversations with your app, and start new conversations. It's hidden by default, you can include a link to open it by adding a line to `config/initializers/intercom.rb`:
+### Messenger
+Intercom includes an in-app messenger which allows a user to read messages and start conversations.
 
-To use the default link style, which requires no extra config and includes a small question mark icon in the bottom right corner of your app:
-
-```ruby
-  config.inbox.style = :default
-```
-
-If you want to customize the style of the link that opens the inbox:
+By default Intercom will add a button that opens the messenger to the page. If you want to customize the style of the link that opens the messenger:
 
 ```ruby
   config.inbox.style = :custom
 ```
 
-This option attaches the inbox open event to the click event of an element with an id of `Intercom`. So the simplest option here would be to add something like the following to your layout:
+With this option enabled, clicks on any element with an id of `Intercom` will open the messenger. So the simplest option here would be to add something like the following to your layout:
 
 ```html
   <a id="Intercom">Support</a>
 ```
 
-You can read more about configuring the Inbox within Intercom (Config menu -> Inbox Link).
+You can read more about configuring the messenger in your applications settings, within Intercom.
 
 ### Environments
 

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -95,14 +95,11 @@ IntercomRails.config do |config|
   # config.company.monthly_spend = Proc.new { |current_company| current_company.plan.price }
   # config.company.monthly_spend = Proc.new { |current_company| (current_company.plan.price - current_company.subscription.discount) }
 
-  # == Inbox Style
-  # This enables the Intercom inbox which allows your users to read their
-  # past conversations with your app, as well as start new ones. It is
-  # disabled by default.
-  #   * :default shows a small tab with a question mark icon on it
-  #   * :custom attaches the inbox open event to an anchor with an
-  #             id of #Intercom.
+  # == Custom Style
+  # By default, Intercom will add a button that opens the messenger to
+  # the page. If you'd like to use your own link to open the messenger,
+  # uncomment this line and clicks on any element with id 'Intercom' will
+  # open the messenger.
   #
-  # config.inbox.style = :default
   # config.inbox.style = :custom
 end


### PR DESCRIPTION
We now add the messenger button by default. This updates the README and config comments to reflect this.
