### PR TITLE
Adds ability to exclude widget from the script tag

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -103,7 +103,7 @@ module IntercomRails
     config_group :inbox do
       config_accessor :counter # Keep this for backwards compatibility
       config_accessor :style do |value|
-        raise ArgumentError, "inbox.style must be one of :default or :custom" unless [:default, :custom].include?(value)
+        raise ArgumentError, "inbox.style must be one of :default, :custom, :none or false" unless [:default, :custom, :none, false].include?(value)
       end
     end
 

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -100,6 +100,8 @@ module IntercomRails
         '#IntercomDefaultWidget'
       when :custom
         '#Intercom'
+      when :none, false
+        nil
       else
         nil
       end

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -100,6 +100,14 @@ describe IntercomRails::ScriptTag do
       IntercomRails.config.inbox.style = :custom
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '#Intercom'})
     end
+    it 'knows about :none' do
+      IntercomRails.config.inbox.style = :none
+      expect(ScriptTag.new.intercom_settings['widget']).to eq(nil)
+    end
+    it 'knows about false' do
+      IntercomRails.config.inbox.style = false
+      expect(ScriptTag.new.intercom_settings['widget']).to eq(nil)
+    end
   end
 
   context 'company' do


### PR DESCRIPTION
Solves issue https://github.com/intercom/intercom-rails/issues/110 by allowing to set `:none` (or false) to `IntercomRails.config.inbox.style`