### PR TITLE
Wrap custom attributes in a hash

### DIFF
--- a/lib/intercom-rails/proxy.rb
+++ b/lib/intercom-rails/proxy.rb
@@ -22,7 +22,9 @@ module IntercomRails
       end
 
       def to_hash
-        data = standard_data.merge(custom_data)
+        data = standard_data
+        custom_attributes = custom_data
+        data[:custom_attributes] = custom_attributes if custom_attributes.present?
         [:id, :user_id].each do |id_key|
           if(data[id_key] && !data[id_key].is_a?(Numeric))
             data[id_key] = data[id_key].to_s

--- a/spec/proxy/user_spec.rb
+++ b/spec/proxy/user_spec.rb
@@ -67,7 +67,7 @@ describe IntercomRails::Proxy::User do
     }
 
     @user_proxy = ProxyUser.new(plan_dummy_user)
-    expect(@user_proxy.to_hash['plan']).to eql('pro')
+    expect(@user_proxy.to_hash[:custom_attributes]['plan']).to eql('pro')
   end
 
   it 'converts dates to timestamps' do
@@ -83,7 +83,7 @@ describe IntercomRails::Proxy::User do
     }
 
     @user_proxy = ProxyUser.new(plan_dummy_user)
-    expect(@user_proxy.to_hash['some_date']).to eq(5)
+    expect(@user_proxy.to_hash[:custom_attributes]['some_date']).to eq(5)
   end
 
   it 'is considered valid if user_id or email' do
@@ -115,7 +115,7 @@ describe IntercomRails::Proxy::User do
     end
 
     @user_proxy = ProxyUser.new(DUMMY_USER, object_with_intercom_custom_data)
-    expect(@user_proxy.to_hash[:ponies]).to eql(:rainbows)
+    expect(@user_proxy.to_hash[:custom_attributes][:ponies]).to eql(:rainbows)
   end
 
   it 'is invalid if whiny nil' do


### PR DESCRIPTION
The documentation is inconsistent but this works whereas adding the custom attributes directly to the top-level hash fails, as documented in issue #105.

The documentation for `users/bulk` doesn't mention custom attributes, but the documentation for "Create or Update User" shows the custom attributes wrapped under the key `custom_attributes` (here: https://doc.intercom.io/api/#create-or-update-user)
