### PR TITLE
Remove duplication of 'possible' in documentation

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -23,7 +23,7 @@ Take note of your `app_id` from [here](https://app.intercom.io/apps/api_keys) an
 rails generate intercom:config YOUR-APP-ID
 ```
 
-To make installing Intercom as easy as possible, where possible a `<script>` tag **will be automatically inserted before the closing `</body>` tag**. For most Rails apps, **you won't need to do any extra config**. Having trouble? Check out troubleshooting below.
+To make installing Intercom as easy as possible, a `<script>` tag **will be automatically inserted before the closing `</body>` tag**. For most Rails apps, **you won't need to do any extra config**. Having trouble? Check out troubleshooting below.
 
 ### Disabling automatic insertion
 


### PR DESCRIPTION
The sentence about the default installation was hard to read, since the
word 'possible' was duplicated.

This change removes the duplication.