### PR TITLE
Sample code block was under the wrong bullet

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -39,11 +39,10 @@ If it's not working make sure:
 * You've generated a config file with your `app_id` as detailed above.
 * Your user object responds to an `id` or `email` method.
 * Your current user is accessible in your controllers as `current_user` or `@user`, if not in `config/initializers/intercom.rb`:
-* If you want the Intercom Messenger to be available when there is no current user,  set `config.include_for_logged_out_users = true` in your config and sign up for the [Acquire](https://www.intercom.io/live-chat) package.
-
 ```ruby
   config.user.current = Proc.new { current_user_object }
 ```
+* If you want the Intercom Messenger to be available when there is no current user,  set `config.include_for_logged_out_users = true` in your config and sign up for the [Acquire](https://www.intercom.io/live-chat) package.
 
 Feel free to mail us: team@intercom.io, if you're still having trouble.
 


### PR DESCRIPTION
The sample code relating to setting a custom current user object was not in the bullet point about this topic.