### PR TITLE
gsub was doing odd things to escaped json

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -25,7 +25,8 @@ module IntercomRails
       end
 
       def include_javascript!
-        response.body = response.body.gsub(CLOSING_BODY_TAG, intercom_script_tag.output + '\\0')
+        split = response.body.split("</body>")
+        response.body = split.first + intercom_script_tag.output + "</body>" + split.last
       end
 
       def include_javascript?

--- a/spec/auto_include_filter_spec.rb
+++ b/spec/auto_include_filter_spec.rb
@@ -56,6 +56,11 @@ class TestController < ActionController::Base
     render :text => params[:body], :content_type => 'text/html'
   end
 
+  def with_some_tricky_string
+    @user = dummy_user(:email => "\\\"foo\"")
+    render :text => params[:body], :content_type => 'text/html'
+  end
+
   def current_user
     raise NameError if params[:action] != 'with_current_user_method'
     dummy_user(:email => 'ciaran@intercom.io', :name => 'Ciaran Lee')
@@ -177,6 +182,11 @@ describe TestController, type: :controller do
   it 'can be skipped with skip_filter' do
     get :with_user_instance_variable_after_filter_skipped, :body => "<body>Hello world</body>"
     expect(response.body).to eq("<body>Hello world</body>")
+  end
+
+  it 'escapes strings with \\s' do
+    get :with_some_tricky_string, :body => "<body>Normal</body>"
+    expect(response.body).to include("\"email\":\"\\\\\\\"foo\\\"\"")
   end
 
   it 'can be disabled in non whitelisted environments' do


### PR DESCRIPTION
Hi,

I was having an issue where `gsub` would remove my backslashes and ruin my escaped strings. Took me a while to find it, and I thought it was in ActiveSupport for a while. My test reproduces the problem, although it's a little tricky to see.

Something like: 

```
rabbits\"}};alert('oh no');
```

ought to be escaped to:

```
rabbits\\\"}};alert('oh no');
```

but was, for some reason, escaped to:

```
rabbits\\"}};alert('oh no');
```

which caused dramas.

Hope this helps.

Huw