### PR TITLE
Add auto include filter hooks for CSP nonce and sha-256

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -21,7 +21,7 @@ module IntercomRails
 
         # User defined method to whitelist the script sha-256 when using CSP
         if defined?(CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook) == 'method'
-          CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook(controller.request, auto_include_filter.csp_sha256)
+          CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook(controller, auto_include_filter.csp_sha256)
         end
       end
 
@@ -74,7 +74,7 @@ module IntercomRails
         # User defined method for applying a nonce to the inserted js tag when
         # using CSP
         if defined?(CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook) == 'method'
-          nonce = CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook(controller.request)
+          nonce = CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook(controller)
           options.merge!(:nonce => nonce)
         end
         @script_tag = ScriptTag.new(options)

--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -65,16 +65,19 @@ module IntercomRails
       end
 
       def intercom_script_tag
+        options = {
+          :find_current_user_details => true,
+          :find_current_company_details => true,
+          :controller => controller,
+          :show_everywhere => show_everywhere?
+        }
         # User defined method for applying a nonce to the inserted js tag when
         # using CSP
         if defined?(CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook) == 'method'
-          # Since the nonce changes with every request, rebuild @script_tag
           nonce = CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook(controller.request)
-          @script_tag = ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller, :show_everywhere => show_everywhere?, :nonce => nonce)
-        else
-          # Nonce not needed, ||= is ok
-          @script_tag ||= ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller, :show_everywhere => show_everywhere?)
+          options.merge!(:nonce => nonce)
         end
+        @script_tag = ScriptTag.new(options)
       end
 
       def show_everywhere?

--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -18,6 +18,11 @@ module IntercomRails
         return unless auto_include_filter.include_javascript?
 
         auto_include_filter.include_javascript!
+
+        # User defined method to whitelist the script sha-256 when using CSP
+        if defined?(CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook) == 'method'
+          CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook(controller.request, auto_include_filter.csp_sha256)
+        end
       end
 
       attr_reader :controller
@@ -38,6 +43,10 @@ module IntercomRails
         intercom_script_tag.valid?
       end
 
+      def csp_sha256
+        intercom_script_tag.csp_sha256
+      end
+
       private
       def response
         controller.response
@@ -56,7 +65,16 @@ module IntercomRails
       end
 
       def intercom_script_tag
-        @script_tag ||= ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller, :show_everywhere => show_everywhere?)
+        # User defined method for applying a nonce to the inserted js tag when
+        # using CSP
+        if defined?(CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook) == 'method'
+          # Since the nonce changes with every request, rebuild @script_tag
+          nonce = CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook(controller.request)
+          @script_tag = ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller, :show_everywhere => show_everywhere?, :nonce => nonce)
+        else
+          # Nonce not needed, ||= is ok
+          @script_tag ||= ScriptTag.new(:find_current_user_details => true, :find_current_company_details => true, :controller => controller, :show_everywhere => show_everywhere?)
+        end
       end
 
       def show_everywhere?

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -72,7 +72,7 @@ module IntercomRails
 
     def csp_sha256
       base64_sha256 = Base64.encode64(Digest::SHA256.digest(intercom_javascript))
-      csp_hash = "sha256-#{base64_sha256}".delete("\n")
+      csp_hash = "'sha256-#{base64_sha256}'".delete("\n")
       csp_hash
     end
 

--- a/spec/auto_include_filter_spec.rb
+++ b/spec/auto_include_filter_spec.rb
@@ -199,4 +199,15 @@ describe TestController, type: :controller do
     expect(response.body).to include(IntercomRails.config.app_id)
     expect(response.body).to include("</script>\n</body>")
   end
+
+  context 'content security policy support' do
+    before do
+      require 'auto_include_filter_spec_csp_helper'
+    end
+    it 'injects nonce if csp_nonce_hook is defined' do
+      IntercomRails.config.api_secret = 'abcd'
+      get :with_current_user_method, :body => "<body>Hello world</body>"
+      expect(response.body).to include('nonce="aaaa"')
+    end
+  end
 end

--- a/spec/auto_include_filter_spec_csp_helper.rb
+++ b/spec/auto_include_filter_spec_csp_helper.rb
@@ -1,0 +1,9 @@
+module CoreExtensions
+  module IntercomRails
+    module AutoInclude
+      def self.csp_nonce_hook(controller)
+        'aaaa'
+      end
+    end
+  end
+end

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -35,7 +35,7 @@ describe IntercomRails::ScriptTagHelper do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq('sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24=')
+      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -160,7 +160,7 @@ describe IntercomRails::ScriptTag do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq('sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24=')
+      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
     end
 
     it 'inserts a valid nonce if present' do


### PR DESCRIPTION
This PR adds auto include filter hooks for managing CSP nonces and sha-256 hashes.
The exposed hooks signatures are:
 - CoreExtensions::IntercomRails::AutoInclude.csp_nonce_hook(controller)
 - CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook(controller, sha-256 entry)

So, for instance, implementing nonce support with https://github.com/twitter/secureheaders can be done as follow:
```
module CoreExtensions
  module IntercomRails
    module AutoInclude
      def self.csp_nonce_hook(controller)
        nonce = SecureHeaders.content_security_policy_script_nonce(controller.request)
        nonce
      end
    end
  end
end
```
or, for sha-256 support:
```
module CoreExtensions
  module IntercomRails
    module AutoInclude
      def self.csp_sha256_hook(controller, sha256)
        SecureHeaders.append_content_security_policy_directives(controller.request, {script_src: [sha256]})
      end
    end
  end
end
```