### PR TITLE
Fix after_filter deprecation warning on Rails 5

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -30,7 +30,7 @@ To make installing Intercom as easy as possible, where possible a `<script>` tag
 To disable automatic insertion for a particular controller or action you can:
 
 ```ruby
-  skip_after_filter :intercom_rails_auto_include
+  skip_after_action :intercom_rails_auto_include
 ```
 
 ### Troubleshooting

--- a/lib/intercom-rails/railtie.rb
+++ b/lib/intercom-rails/railtie.rb
@@ -4,7 +4,11 @@ module IntercomRails
       ActionView::Base.send :include, ScriptTagHelper
       ActionController::Base.send :include, CustomDataHelper
       ActionController::Base.send :include, AutoInclude::Method
-      ActionController::Base.after_filter :intercom_rails_auto_include
+      if ActionController::Base.respond_to? :after_action
+        ActionController::Base.after_action :intercom_rails_auto_include
+      else
+        ActionController::Base.after_filter :intercom_rails_auto_include
+      end
     end
 
     rake_tasks do

--- a/spec/action_controller_spec_helper.rb
+++ b/spec/action_controller_spec_helper.rb
@@ -29,7 +29,11 @@ end
 class ActionController::Base
   include IntercomRails::CustomDataHelper
   include IntercomRails::AutoInclude::Method
-  after_filter :intercom_rails_auto_include
+  if respond_to? :after_action
+    after_action :intercom_rails_auto_include
+  else
+    after_filter :intercom_rails_auto_include
+  end
 
   include TestRoutes.url_helpers
   include TestRoutes.mounted_helpers

--- a/spec/auto_include_filter_spec.rb
+++ b/spec/auto_include_filter_spec.rb
@@ -1,7 +1,11 @@
 require 'action_controller_spec_helper'
 
 class TestController < ActionController::Base
-  skip_after_filter :intercom_rails_auto_include, :only => :with_user_instance_variable_after_filter_skipped
+  if respond_to? :skip_after_action
+    skip_after_action :intercom_rails_auto_include, :only => :with_user_instance_variable_after_filter_skipped
+  else
+    skip_after_filter :intercom_rails_auto_include, :only => :with_user_instance_variable_after_filter_skipped
+  end
 
   def without_user
     render_content("<body>Hello world</body>")


### PR DESCRIPTION
With #168 and #169 in place, I can finally make this change :smile: 

In Rails 4, the `after_filter` method was renamed to `after_action`. The older method was still supported until Rails 5, which now prints a deprecation warning when `after_filter` is used:

> DEPRECATION WARNING: after_filter is deprecated and will be removed in Rails 5.1. Use after_action instead.

With this change we'll use `after_action` if it's available, but will continue to use `after_filter` on older versions of Rails.