### PR TITLE
erase session cookie when user logout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    intercom-rails (0.2.30)
+    intercom-rails (0.2.31)
       activesupport (> 3.0)
 
 GEM
@@ -111,3 +111,6 @@ DEPENDENCIES
   sinatra (~> 1.4.5)
   thin (~> 1.6.2)
   tzinfo
+
+BUNDLED WITH
+   1.11.2

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -18,12 +18,26 @@ module IntercomRails
       self.controller = options[:controller]
       @show_everywhere = options[:show_everywhere]
       self.user_details = options[:find_current_user_details] ? find_current_user_details : options[:user_details]
+      remove_user_cookie_on_logout if http_request?
       self.company_details = if options[:find_current_company_details]
         find_current_company_details
       elsif options[:user_details]
         options[:user_details].delete(:company) if options[:user_details]
       end
       self.nonce = options[:nonce]
+    end
+
+    def remove_user_cookie_on_logout
+      if (find_current_user_details == {} && controller.response.request.cookies["intercom-session-#{IntercomRails.config.app_id}"])
+        controller.response.set_cookie("intercom-session-#{IntercomRails.config.app_id}", :value => "", :expires => Time.at(0))
+      end
+    end
+
+    def http_request?
+      return ( defined?(controller) &&
+        defined?(controller.response) &&
+        defined?(controller.response.request) &&
+        defined?(controller.response.set_cookie) )
     end
 
     def valid?

--- a/spec/auto_include_filter_spec.rb
+++ b/spec/auto_include_filter_spec.rb
@@ -228,4 +228,19 @@ describe TestController, type: :controller do
       expect(response.body).to include('nonce="aaaa"')
     end
   end
+  context 'clear session on user logout' do
+    it 'clear intercom-session-app_id cookie if user just logged out' do
+      request.cookies["intercom-session-#{IntercomRails.config.app_id}"] = "intercom-session-cookie"
+      get :without_user
+      expect(response.cookies).to eq({"intercom-session-#{IntercomRails.config.app_id}" => nil}) # nil Erase the cookie
+    end
+    it 'do not clear intercom-session-app_id cookie if lead' do
+      get :without_user
+      expect(response.cookies).to eq({})
+    end
+    it 'do not clear intercom-session-app_id cookie if user logged in' do
+      get :with_user_instance_variable
+      expect(response.cookies).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
- Erase the intercom-session-{app_id} when user log out
Since intercom-id cookie is still here, the lead still have his conversations on page refresh or page navigation
- Downgrade rake (<11.0) to fix  [Failing Travis Test](https://travis-ci.org/intercom/intercom-rails/builds/114953835) :  "last_comment" method removed from Rake in last update (11.0.1) creating an error