### PR TITLE
clarified documentation about current_company confusion

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -127,6 +127,10 @@ Basic usage is as follows - in `config/initializers/intercom.rb`
 config.company.current = Proc.new { current_company }
 ```
 
+`current_company` is the method/variable that contains the user's current company in your controllers.
+If you are using devise you should replace `current_company` with `current_user.company` in the above code and every time you see 'current_company' in your configuration file.
+This will result in injecting the user current company in the widget settings.
+
 and like with Users, you can set custom attribute on companies too:
 
 ```ruby

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -71,6 +71,7 @@ IntercomRails.config do |config|
   # == User -> Company association
   # A Proc that given a user returns an array of companies
   # that the user belongs to.
+  # This is only used for importing users using rake command but it will not inject a list of companies in the intercom widget
   #
   # config.user.company_association = Proc.new { |user| user.companies.to_a }
   # config.user.company_association = Proc.new { |user| [user.company] }
@@ -81,6 +82,11 @@ IntercomRails.config do |config|
   # could be a company, app or group.
   #
   # config.company.current = Proc.new { current_company }
+  #
+  # Or if you are using devise you can just use the following config
+  #
+  # config.company.current = Proc.new { current_user.company }
+
 
   # == Company Custom Data
   # A hash of additional data you wish to send about a company.


### PR DESCRIPTION
related to https://github.com/intercom/intercom-rails/issues/118

 - `config.company.current = Proc.new { current_company }` is used to insert the user current company in the the widget settings. 
 - `current_company` in the above code is not an intercom helper and can be replaced in most cases (devise) by `current_user.company`
 -  `config.user.company_association = Proc.new { |user| user.companies.to_a }` is uniquely used to perform bulk api user import using `rake intercom:import` command but is not injecting any new settings in intercom's widget.

In sum, it doesn't really make sense to track user events related to several companies at the same time that's why we do not inject companies in the widget settings.
But since a user can be related to several companies it is possible to import the users with several companies using `config.user.company_association = Proc.new { |user| user.companies.to_a }`

I have a question though, and a customer is facing this problem : why isn't it possible to run `rake intercom:import` in development ? It is really inconvenient when developing/debugging. 

Should we instead warn the developer of his action ? 
"You are about to import your local user database in your intercom application. Are you sure you want to continue ? (Y/n)"

@bobjflong @RuairiK 