### PR TITLE
fix specs dep issues

### DIFF
--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
+gem 'mime-types', '2.6.2'
 
 gemspec :path => '../'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
+gem 'mime-types', '2.6.2'
 
 gemspec :path => '../'


### PR DESCRIPTION
@RuairiK  
Does that fix our issue ? Anyway if a customer uses mime-types > 2.6 then he will have to use ruby > 2.0 so the number of customers currently using ruby1.9 with mime-types3.0 should be 0.