### PR TITLE
Restore Config.api_key= with deprecation warning

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -98,6 +98,10 @@ module IntercomRails
     config_accessor :enabled_environments, &ARRAY_VALIDATOR
     config_accessor :include_for_logged_out_users
 
+    def self.api_key=(*)
+      warn "Setting an Intercom API key is no longer supported; remove the `config.api_key = ...` line from config/initializers/intercom.rb"
+    end
+
     config_group :user do
       config_accessor :current, &IS_PROC_OR_ARRAY_OF_PROC_VALIDATOR
       config_accessor :exclude_if, &IS_PROC_VALIDATOR

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -75,4 +75,10 @@ describe IntercomRails do
     expect(IntercomRails.config.user.custom_data).to eq(nil)
     expect(IntercomRails.config.inbox.style).to eq(nil)
   end
+
+  it 'prints a deprecation warning when #api_key= is used' do
+    expect do
+      IntercomRails.config.api_key = "foo"
+    end.to output(/no longer supported/).to_stderr
+  end
 end


### PR DESCRIPTION
https://github.com/intercom/intercom-rails/pull/205 removed the import rake task, along with the associated `api_key` configuration option. This means that users who have added an API key to their initializer will get this error when they update the gem:

    NoMethodError:  method `api_key=' for IntercomRails::Config:Class

This brings back the method, but without any behaviour; it just prints a deprecation warning. This will allow those users to update to the latest version of the gem without causing an error when their app boots.

/cc @travega