### PR TITLE
Add the ability to use custom attributes for leads

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -173,6 +173,38 @@ end
 Attributes must be accessible in order to sync with intercom.
 Additionally, attributes ending in "_at" will be parsed as times.
 
+### Custom attributes for non-signed up users
+
+In situations where you want to pass in specific request based custom data for non-signed up users or leads,
+you can do that by setting custom attributes in ```config/initializers/intercom.rb```.
+
+Any of these attributes can be used to pass in custom data.
+
+Example:
+
+**in ```config/initializers/intercom.rb```**
+
+```ruby
+config.user.lead_attributes = %w(ref_data utm_source)
+```
+
+**in ```app/controllers/posts_controller.rb```**
+
+```ruby
+class PostsController < ApplicationController
+
+  before_action :set_custom_attributes, only: [:index]
+
+  # Your logic here
+
+  protected
+  def set_custom_attributes
+    intercom_custom_data.user[:ref_data] = params[:api_ref_data]
+    intercom_custom_data.user[:utm_source] = params[:api_utm_source]
+  end
+end
+```
+
 ### Companies
 
 By default, Intercom treats all Users as unrelated individuals. If for example you know users are part of a company, you can group them as such.

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -106,6 +106,7 @@ module IntercomRails
       config_accessor :current, &IS_PROC_OR_ARRAY_OF_PROC_VALIDATOR
       config_accessor :exclude_if, &IS_PROC_VALIDATOR
       config_accessor :model, &IS_PROC_VALIDATOR
+      config_accessor :lead_attributes, &ARRAY_VALIDATOR
       config_accessor :custom_data, &CUSTOM_DATA_VALIDATOR
 
       def self.company_association=(*)

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -86,8 +86,10 @@ module IntercomRails
       lead_attributes = IntercomRails.config.user.lead_attributes
       return {} unless controller.present? && lead_attributes && lead_attributes.size > 0
 
-      query_parameters = controller.request.query_parameters.with_indifferent_access
-      query_parameters.select {|k, v| lead_attributes.map(&:to_s).include?(k)}
+      # Get custom data. This also allows to retrieve custom data
+      # set via helper function intercom_custom_data
+      custom_data = controller.intercom_custom_data.user.with_indifferent_access
+      custom_data.select {|k, v| lead_attributes.map(&:to_s).include?(k)}
     end
 
     private

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -50,6 +50,13 @@ IntercomRails.config do |config|
   #
   # config.user.model = Proc.new { User }
 
+  # == Lead/custom attributes for non-signed up users
+  # Pass additional attributes to for potential leads or
+  # non-signed up users as an an array.
+  # Any attribute contained in config.user.lead_attributes can be used
+  # as custom attribute in the application.
+  # config.user.lead_attributes = %w(ref_data utm_source)
+
   # == Exclude users
   # A Proc that given a user returns true if the user should be excluded
   # from imports and Javascript inclusion, false otherwise.

--- a/spec/proxy/user_spec.rb
+++ b/spec/proxy/user_spec.rb
@@ -135,4 +135,13 @@ describe IntercomRails::Proxy::User do
     search_object = nil
     expect(ProxyUser.new(search_object).valid?).to eq(false)
   end
+
+  it 'gets/sets lead_attributes' do
+    IntercomRails.config.user.lead_attributes = %w(utm_source ref_data)
+    expect(IntercomRails.config.user.lead_attributes).to eq(["utm_source", "ref_data"])
+  end
+
+  it 'gets/sets lead_attributes with valid types' do
+    expect { IntercomRails.config.user.lead_attributes = "utm_source" }.to raise_error(ArgumentError)
+  end
 end

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -204,10 +204,10 @@ describe IntercomRails::ScriptTag do
 
       controller_with_request = Object.new
       controller_with_request.instance_eval do
-        def request
+        def intercom_custom_data
           Object.new.tap do |o|
             o.instance_eval do
-              def query_parameters
+              def user
                 {
                   utm_source: 'google',
                   ref_data: 12345,

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -192,4 +192,41 @@ describe IntercomRails::ScriptTag do
       expect(script_tag.to_s).not_to include('>alert(1)</script><script>')
     end
   end
+
+  context 'request specific parameters' do
+    it 'does not complain when no controller is found' do
+      script_tag = ScriptTag.new(utm_source: 'google')
+      expect(script_tag.intercom_settings[:utm_source]).to eq(nil)
+    end
+
+    it 'accepts request specific defined lead attributes and rejects rest' do
+      IntercomRails.config.user.lead_attributes = %w(utm_source ref_data)
+
+      controller_with_request = Object.new
+      controller_with_request.instance_eval do
+        def request
+          Object.new.tap do |o|
+            o.instance_eval do
+              def query_parameters
+                {
+                  utm_source: 'google',
+                  ref_data: 12345,
+                  ad_data: 'something1234'
+                }
+              end
+            end
+          end
+        end
+      end
+
+      script_tag = ScriptTag.new(controller: controller_with_request)
+
+      expect(script_tag.intercom_settings[:utm_source]).to eq('google')
+      expect(script_tag.intercom_settings[:ref_data]).to eq(12345)
+      # Rejects
+      expect(script_tag.intercom_settings[:ad_data]).to eq(nil)
+    end
+
+  end
+
 end


### PR DESCRIPTION
* ~~Extending users, so applications can use users as potential leads.~~
* ~~Enables to pass in custom attrs for leads~~
* ~~Option is not made available by default. So a config needs to be set in the initializer.```config.user.as_lead = true```~~
* ~~Explanation of the same is added in ```intercom.rb.erb```~~

* Introducing custom attributes for non-signed up users / leads using ```ScriptTag```.
* Application can set config ``` config.user.lead_attributes``` with an array of attributes they would like to track/use. This way not all request specific parameters are sent as custom attributes, but only the ones desired.
* Config file and README doc updated.

/cc @eugeneius 