### PR TITLE
Deprecate Config.user.company_association

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -106,8 +106,11 @@ module IntercomRails
       config_accessor :current, &IS_PROC_OR_ARRAY_OF_PROC_VALIDATOR
       config_accessor :exclude_if, &IS_PROC_VALIDATOR
       config_accessor :model, &IS_PROC_VALIDATOR
-      config_accessor :company_association, &IS_PROC_VALIDATOR
       config_accessor :custom_data, &CUSTOM_DATA_VALIDATOR
+
+      def self.company_association=(*)
+        warn "Setting a company association is no longer supported; remove the `config.user.company_association = ...` line from config/initializers/intercom.rb"
+      end
     end
 
     config_group :company do

--- a/lib/intercom-rails/proxy/company.rb
+++ b/lib/intercom-rails/proxy/company.rb
@@ -11,14 +11,6 @@ module IntercomRails
       config_delegator :plan
       config_delegator :monthly_spend
 
-      def self.companies_for_user(user)
-        return unless config(:user).company_association.present?
-        companies = config(:user).company_association.call(user.user)
-        return unless companies.kind_of?(Array)
-
-        companies.map { |company| new(company) }.select { |company_proxy| company_proxy.valid? }
-      end
-
       def self.current_in_context(search_object)
         begin
           if config.current.present?

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -66,14 +66,6 @@ IntercomRails.config do |config|
   #   :favorite_color => :favorite_color
   # }
 
-  # == User -> Company association
-  # A Proc that given a user returns an array of companies
-  # that the user belongs to.
-  # This is only used for importing users using rake command but it will not inject a list of companies in the intercom widget
-  #
-  # config.user.company_association = Proc.new { |user| user.companies.to_a }
-  # config.user.company_association = Proc.new { |user| [user.company] }
-
   # == Current company method/variable
   # The method/variable that contains the current company for the current user,
   # in your controllers. 'Companies' are generic groupings of users, so this

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -81,4 +81,10 @@ describe IntercomRails do
       IntercomRails.config.api_key = "foo"
     end.to output(/no longer supported/).to_stderr
   end
+
+  it 'prints a deprecation warning when user.company_association= is used' do
+    expect do
+      IntercomRails.config.user.company_association = Proc.new { [] }
+    end.to output(/no longer supported/).to_stderr
+  end
 end

--- a/spec/proxy/company_spec.rb
+++ b/spec/proxy/company_spec.rb
@@ -25,18 +25,4 @@ describe IntercomRails::Proxy::Company do
     search_object = nil
     expect(ProxyCompany.new(search_object).valid?).to eq(false)
   end
-
-  it 'does companies for user' do
-    IntercomRails.config.user.company_association = Proc.new { |user| user.apps }
-    test_user = dummy_user
-    test_user.instance_eval do
-      def apps
-        [DUMMY_COMPANY, dummy_company(:name => "Prey", :id => "800")]
-      end
-    end
-
-    companies = ProxyCompany.companies_for_user(IntercomRails::Proxy::User.new(test_user))
-    expect(companies.length).to eq(2)
-    expect(companies.map(&:company).map(&:name)).to eq(["Intercom", "Prey"])
-  end
 end


### PR DESCRIPTION
This setting was only used from the import task, which no longer exists.