### PR TITLE
Fix for Issue 214

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -17,7 +17,7 @@ Then run:
 bundle install
 ```
 
-Take note of your `app_id` from [here](https://app.intercom.io/apps/api_keys) and generate a config file:
+Take note of your `app_id` from [here](https://app.intercom.io/apps/settings/api-keys) and generate a config file:
 
 ```
 rails generate intercom:config YOUR-APP-ID

--- a/README.mdown
+++ b/README.mdown
@@ -17,7 +17,7 @@ Then run:
 bundle install
 ```
 
-Take note of your `app_id` from [here](https://app.intercom.io/apps/settings/api-keys) and generate a config file:
+Take note of your `app_id` from [here](https://app.intercom.io/a/apps/_/settings/api-keys) and generate a config file:
 
 ```
 rails generate intercom:config YOUR-APP-ID


### PR DESCRIPTION
Link to app ID in docs appears to be broken #214 
Added correct link to take you to API Key page