### PR TITLE
Update README.mdown

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -25,6 +25,14 @@ rails generate intercom:config YOUR-APP-ID
 
 To make installing Intercom as easy as possible, where possible a `<script>` tag **will be automatically inserted before the closing `</body>` tag**. For most Rails apps, **you won't need to do any extra config**. Having trouble? Check out troubleshooting below.
 
+
+### Live Chat / Acquire
+With our [Acquire package](https://www.intercom.io/live-chat), Intercom Messenger now works with logged out users and visitors to your web site. Include the Intercom snippet on every page by setting:
+
+```ruby
+  config.include_for_logged_out_users = true
+```
+
 ### Disabling automatic insertion
 
 To disable automatic insertion for a particular controller or action you can:
@@ -228,13 +236,6 @@ config.company.custom_data = {
   :number_of_messages => Proc.new { |app| app.messages.count },
   :is_interesting => :is_interesting?
 }
-```
-
-### Live Chat / Acquire
-With our [Acquire package](https://www.intercom.io/live-chat), Intercom Messenger now works with logged out users and visitors to your web site. Include the Intercom snippet on every page by setting:
-
-```ruby
-  config.include_for_logged_out_users = true
 ```
 
 ### Messenger


### PR DESCRIPTION
It makes more sense to show this part of doc right after the developer generated the code. 
The first thing a dev does after generating the code is checking if the messenger shows up on his website. If it doesn't it is frustrating and the dev starts to inspect the console and the code when he just needs to turn on this config but didn't saw it in the docs.