### PR TITLE
add hide_default_launcher

### DIFF
--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -64,6 +64,7 @@ module IntercomRails
       hsh[:session_duration] = @session_duration if @session_duration.present?
       hsh[:widget] = widget_options if widget_options.present?
       hsh[:company] = company_details if company_details.present?
+      hsh[:hide_default_launcher] = Config.inbox.style == :custom
       hsh
     end
 

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -35,7 +35,7 @@ describe IntercomRails::ScriptTagHelper do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
+      expect(script_tag.csp_sha256).to eq("'sha256-QmMmBpC2AxZc9zd18FvMACQwKPbnGG/kGMN4dGJeB3w='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -118,11 +118,13 @@ describe IntercomRails::ScriptTag do
     it 'knows about :custom' do
       IntercomRails.config.inbox.style = :custom
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '#Intercom'})
+      expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(true)
     end
     it 'knows about :custom_activator' do
       IntercomRails.config.inbox.style = :custom
       IntercomRails.config.inbox.custom_activator = '.intercom'
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '.intercom'})
+      expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(true)
     end
   end
 
@@ -169,7 +171,7 @@ describe IntercomRails::ScriptTag do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
+      expect(script_tag.csp_sha256).to eq("'sha256-QmMmBpC2AxZc9zd18FvMACQwKPbnGG/kGMN4dGJeB3w='")
     end
 
     it 'inserts a valid nonce if present' do


### PR DESCRIPTION
If `Config.inbox.style` is set to `:custom` hide default launcher button. This adds backward compatibility with previous version of messenger.

https://github.com/intercom/intercom-rails/issues/218