### PR TITLE
add hide_default_launcher to config

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -261,6 +261,12 @@ You can customize the CSS selector, by setting
   config.inbox.custom_activator = '.intercom-link'
 ```
 
+You can hide default launcher button, by setting
+
+```ruby
+  config.hide_default_launcher = true
+```
+
 You can read more about configuring the messenger in your applications settings, within Intercom.
 
 ### Environments

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -107,6 +107,7 @@ module IntercomRails
     config_accessor :library_url
     config_accessor :enabled_environments, &ARRAY_VALIDATOR
     config_accessor :include_for_logged_out_users
+    config_accessor :hide_default_launcher
 
     def self.api_key=(*)
       warn "Setting an Intercom API key is no longer supported; remove the `config.api_key = ...` line from config/initializers/intercom.rb"

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -64,7 +64,7 @@ module IntercomRails
       hsh[:session_duration] = @session_duration if @session_duration.present?
       hsh[:widget] = widget_options if widget_options.present?
       hsh[:company] = company_details if company_details.present?
-      hsh[:hide_default_launcher] = Config.inbox.style == :custom
+      hsh[:hide_default_launcher] = Config.hide_default_launcher if Config.hide_default_launcher
       hsh
     end
 

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -124,4 +124,7 @@ IntercomRails.config do |config|
   # uncomment this line and clicks on any element that matches the query will
   # open the messenger
   # config.inbox.custom_activator = '.intercom'
+  #
+  # If you'd like to hide default launcher button uncomment this line
+  # config.hide_default_launcher = true
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -51,6 +51,11 @@ describe IntercomRails do
     expect(IntercomRails.config.inbox.custom_activator).to eq('.intercom')
   end
 
+  it 'gets/sets hide_default_launcher' do
+    IntercomRails.config.hide_default_launcher = true
+    expect(IntercomRails.config.hide_default_launcher).to eq(true)
+  end
+
   it 'raises error if current user not a proc' do
     expect { IntercomRails.config.user.current = 1 }.to raise_error(ArgumentError)
   end

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -35,7 +35,7 @@ describe IntercomRails::ScriptTagHelper do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-QmMmBpC2AxZc9zd18FvMACQwKPbnGG/kGMN4dGJeB3w='")
+      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -118,12 +118,14 @@ describe IntercomRails::ScriptTag do
     it 'knows about :custom' do
       IntercomRails.config.inbox.style = :custom
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '#Intercom'})
-      expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(true)
     end
     it 'knows about :custom_activator' do
       IntercomRails.config.inbox.style = :custom
       IntercomRails.config.inbox.custom_activator = '.intercom'
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '.intercom'})
+    end
+    it 'knows about :hide_default_launcher' do
+      IntercomRails.config.hide_default_launcher = true
       expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(true)
     end
   end
@@ -171,7 +173,7 @@ describe IntercomRails::ScriptTag do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-QmMmBpC2AxZc9zd18FvMACQwKPbnGG/kGMN4dGJeB3w='")
+      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
     end
 
     it 'inserts a valid nonce if present' do


### PR DESCRIPTION
reverts https://github.com/intercom/intercom-rails/pull/231 and adds `hide_default_launcher` to config
fixes https://github.com/intercom/intercom-rails/issues/218