### PR TITLE
Bring custom widget default in line with mv3, remove forcing of default activator

### DIFF
--- a/intercom-rails.gemspec
+++ b/intercom-rails.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'activesupport', '>3.0'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '< 11.0'
   s.add_development_dependency 'actionpack', '>3.2.12'
+  s.add_development_dependency 'nokogiri', '< 1.7.0'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'rspec-rails', '~> 3.1'
   s.add_development_dependency 'pry'

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -160,8 +160,6 @@ module IntercomRails
 
       custom_activator = Config.inbox.custom_activator
       activator = case Config.inbox.style
-      when :default
-        '#IntercomDefaultWidget'
       when :custom
         custom_activator || '#Intercom'
       else

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -113,8 +113,10 @@ IntercomRails.config do |config|
   # config.company.monthly_spend = Proc.new { |current_company| (current_company.plan.price - current_company.subscription.discount) }
 
   # == Custom Style
-  # By default, Intercom will add a button that opens the messenger to
-  # the page. If you'd like to use your own link to open the messenger,
+  # By default, Intercom will display the default launcher widget based on your
+  # preferences set within your App Settings panel, within Messenger Appearance:
+  # https://intercomrades.intercom.com/a/apps/3qmk5gyg/settings/appearance
+  # If you'd like to use your own link to open the messenger,
   # uncomment this line and clicks on any element with id 'Intercom' will
   # open the messenger.
   #

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -111,10 +111,6 @@ describe IntercomRails::ScriptTag do
   end
 
   context 'inbox style' do
-    it 'knows about :default' do
-      IntercomRails.config.inbox.style = :default
-      expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '#IntercomDefaultWidget'})
-    end
     it 'knows about :custom' do
       IntercomRails.config.inbox.style = :custom
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '#Intercom'})


### PR DESCRIPTION
Currently the `intercom-rails` gem is forcing the display of the Intercom default activator by inserting `"widget":{"activator":"#IntercomDefaultWidget"` into the `intercomSettings` hash when `config/initializers/intercom.rb` is assigned the `config.inbox.style = :default` default attribute. This activator overrides the settings defined in the Intercom Settings panel:
![image](https://cloud.githubusercontent.com/assets/5881537/21933137/17d9c5f4-d99c-11e6-8377-5dc6bf7d73e2.png)

Removing the default case from the switch statement will ensure that existing and future implementations that use the `:default` value have the correct behavior of no `activator` value being added to the `intercomSettings` object.