### PR TITLE
removed references to deprecated Acquire package

### DIFF
--- a/lib/intercom-rails/shutdown_helper.rb
+++ b/lib/intercom-rails/shutdown_helper.rb
@@ -2,7 +2,6 @@ module IntercomRails
   module ShutdownHelper
     # This helper allows to erase cookies when a user log out of an application
     # It is recommanded to call this function every time a user log out of your application
-    # specifically if you use both "Acquire" and another Intercom product
     # Do not use before a redirect_to because it will not clear the cookies on a redirection
     def self.intercom_shutdown_helper(cookies)
       if (cookies.is_a?(ActionDispatch::Cookies::CookieJar))

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -38,7 +38,7 @@ IntercomRails.config do |config|
 
   # == Include for logged out Users
   # If set to true, include the Intercom messenger on all pages, regardless of whether
-  # The user model class (set below) is present. Only available for Apps on the Acquire plan.
+  # The user model class (set below) is present.
   <%- if @include_for_logged_out_users -%>
   config.include_for_logged_out_users = true
   <%- else -%>


### PR DESCRIPTION
We no longer use Acquire and all its functionality is available in the Respond product. Can get a bit confusing for someone that doesn't know this when following these steps.