### PR TITLE
Fix outdated intercom-ruby example

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,10 @@ end
 
 class DeleteFromIntercom < ApplicationJob
   def perform(user)
-    intercom = Intercom::Client.new
-    intercom.users.find(email: user.email).delete
+    intercom = Intercom::Client.new(token: 'my_token')
+    user     = intercom.users.find(email: user.email)
+    
+    intercom.users.delete(user)
   end
 end
 ```


### PR DESCRIPTION
The delete example of intercom-ruby gem did not work for me so I corrected it to follow the current syntax.