### PR TITLE
Don't assume @user is the currently logged in user

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If it's not working make sure:
 
 * You've generated a config file with your `app_id` as detailed above.
 * Your user object responds to an `id` or `email` method.
-* Your current user is accessible in your controllers as `current_user` or `@user`, if not in `config/initializers/intercom.rb`:
+* Your current user is accessible in your controllers as `current_user`, if not in `config/initializers/intercom.rb`:
 ```ruby
   config.user.current = Proc.new { current_user_object }
 ```

--- a/lib/intercom-rails/proxy/user.rb
+++ b/lib/intercom-rails/proxy/user.rb
@@ -10,8 +10,7 @@ module IntercomRails
       proxy_delegator :created_at
 
       PREDEFINED_POTENTIAL_USER_OBJECTS = [
-        Proc.new { current_user },
-        Proc.new { @user }
+        Proc.new { current_user }
       ]
 
       def self.potential_user_objects

--- a/spec/proxy/user_spec.rb
+++ b/spec/proxy/user_spec.rb
@@ -21,14 +21,15 @@ describe IntercomRails::Proxy::User do
     expect(@user_proxy.user).to eq(DUMMY_USER)
   end
 
-  it 'finds user instance variable' do
+  it 'does not expose instance variables' do
     object_with_instance_variable = Object.new
     object_with_instance_variable.instance_eval do
       @user = DUMMY_USER
     end
 
-    @user_proxy = ProxyUser.current_in_context(object_with_instance_variable)
-    expect(@user_proxy.user).to eq(DUMMY_USER)
+    expect {
+      ProxyUser.current_in_context(object_with_instance_variable)
+    }.to raise_error(IntercomRails::NoUserFoundError)
   end
 
   it 'finds config user' do


### PR DESCRIPTION
Closes #222 

This is a breaking change that removes what is a risky default in the integration with the Rails app:

Assuming that `@user` is the currently logged in user, thus assuming we can safely show potentielly personal messages to the currently logged in user.

After this change, you'll have to explicitly allow intercom-rails to dig into your instance variables to find the currently logged in user, if you don't have a `current_user` method.

This is done by configuring `IntercomRails.config.user.current` with a Proc:

    config.user.current = Proc.new { @user }

or to preserve the previous behaviour:

    config.user.current = [
      Proc.new { current_user },
      Proc.new { @user }
    ]

Again, this change breaks existing behaviour, so shouldn't be merged and rolled out willynilly, but belongs in a major version update.