### PR TITLE
Make CI pass again on older Ruby/Rails versions

### DIFF
--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,5 +2,6 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
 gem 'mime-types', '2.6.2'
+gem 'nokogiri', '< 1.7.0'
 
 gemspec :path => '../'


### PR DESCRIPTION
Nokogiri 1.7 requires Ruby >= 2.1.0, whereas we run the Rails 4.2 tests on Ruby 1.9.3 on Travis.

This causes test failures like:

    Gem::InstallError: nokogiri requires Ruby version >= 2.1.0.
    An error occurred while installing nokogiri (1.7.2), and Bundler
    cannot continue.
    Make sure that `gem install nokogiri -v '1.7.2'` succeeds before bundling.
    In rails42.gemfile:
      rails was resolved to 4.2.8, which depends on
        actionmailer was resolved to 4.2.8, which depends on
          actionpack was resolved to 4.2.8, which depends on
            actionview was resolved to 4.2.8, which depends on
              rails-dom-testing was resolved to 1.0.8, which depends on
                nokogiri
    The command "eval bundle install --jobs=3 --retry=3 " failed 3 times.

Locking the Nokogiri version to a version prior to 1.7.0 should fix the above issues.