### PR TITLE
Change cookie name in ShutdownHelper

### DIFF
--- a/lib/intercom-rails/shutdown_helper.rb
+++ b/lib/intercom-rails/shutdown_helper.rb
@@ -5,11 +5,11 @@ module IntercomRails
     # Do not use before a redirect_to because it will not clear the cookies on a redirection
     def self.intercom_shutdown_helper(cookies)
       if (cookies.is_a?(ActionDispatch::Cookies::CookieJar))
-        cookies["intercom-session-#{IntercomRails.config.app_id}"] = { value: nil, expires: 1.day.ago}
+        cookies["intercom-id-#{IntercomRails.config.app_id}"] = { value: nil, expires: 1.day.ago}
       else
         controller = cookies
         Rails.logger.info("Warning: IntercomRails::ShutdownHelper.intercom_shutdown_helper takes an instance of ActionDispatch::Cookies::CookieJar as an argument since v0.2.34. Passing a controller is depreciated. See https://github.com/intercom/intercom-rails#shutdown for more details.")
-        controller.response.delete_cookie("intercom-session-#{IntercomRails.config.app_id}", { value: nil, expires: 1.day.ago})
+        controller.response.delete_cookie("intercom-id-#{IntercomRails.config.app_id}", { value: nil, expires: 1.day.ago})
       end
     rescue
     end

--- a/spec/shutdown_helper_spec.rb
+++ b/spec/shutdown_helper_spec.rb
@@ -5,7 +5,7 @@ describe TestController, type: :controller do
   include IntercomRails::ShutdownHelper
   it 'clears response intercom-session-{app_id} cookie' do
     IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies)
-    expect(cookies.has_key?('intercom-session-abc123')).to eq true
+    expect(cookies.has_key?('intercom-id-abc123')).to eq true
   end
   it 'creates session[:perform_intercom_shutdown] var' do
     IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
@@ -15,6 +15,6 @@ describe TestController, type: :controller do
     session[:perform_intercom_shutdown] = true
     IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies)
     expect(session[:perform_intercom_shutdown]).to eq nil
-    expect(cookies.has_key?('intercom-session-abc123')).to eq true
+    expect(cookies.has_key?('intercom-id-abc123')).to eq true
   end
 end


### PR DESCRIPTION
Looks like the Intercom JS lib uses the cookie name 'intercom-id-<app_id>' and not 'intercom-session-<app_id>' anymore.