### PR TITLE
Remove cookie on signout by specifying domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class VisitorsController < ApplicationController
 
   protected
   def intercom_shutdown
-    IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies)
+    IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies, request.domain)
   end
 end
 ```
@@ -125,7 +125,7 @@ end
 If you use another service than Devise or if you implemented your own authentication service, you can call the following method in a controller to shutdown Intercom on logout.
 
 ```ruby
-IntercomRails::ShutdownHelper::intercom_shutdown_helper(cookies)
+IntercomRails::ShutdownHelper::intercom_shutdown_helper(cookies, domain)
 ```
 
 **Be aware that if you call this method before a 'redirect_to' (quite common on logout) it will have no impact** as it is impossible to update cookies when you use a redirection.

--- a/lib/intercom-rails/shutdown_helper.rb
+++ b/lib/intercom-rails/shutdown_helper.rb
@@ -4,12 +4,15 @@ module IntercomRails
     # It is recommanded to call this function every time a user log out of your application
     # Do not use before a redirect_to because it will not clear the cookies on a redirection
     def self.intercom_shutdown_helper(cookies, domain = nil)
+      nil_session = { value: nil, expires: 1.day.ago }
+      nil_session = nil_session.merge(domain: domain) unless domain.nil? || domain == 'localhost'
+
       if (cookies.is_a?(ActionDispatch::Cookies::CookieJar))
-        cookies["intercom-session-#{IntercomRails.config.app_id}"] = { value: nil, expires: 1.day.ago }.merge(domain.present? ? { domain: ".#{domain}"} : {})
+        cookies["intercom-session-#{IntercomRails.config.app_id}"] = nil_session
       else
         controller = cookies
         Rails.logger.info("Warning: IntercomRails::ShutdownHelper.intercom_shutdown_helper takes an instance of ActionDispatch::Cookies::CookieJar as an argument since v0.2.34. Passing a controller is depreciated. See https://github.com/intercom/intercom-rails#shutdown for more details.")
-        controller.response.delete_cookie("intercom-session-#{IntercomRails.config.app_id}", { value: nil, expires: 1.day.ago }).merge(domain.present? ? { domain: ".#{domain}"} : {})
+        controller.response.delete_cookie("intercom-session-#{IntercomRails.config.app_id}", nil_session)
       end
     rescue
     end

--- a/lib/intercom-rails/shutdown_helper.rb
+++ b/lib/intercom-rails/shutdown_helper.rb
@@ -3,13 +3,13 @@ module IntercomRails
     # This helper allows to erase cookies when a user log out of an application
     # It is recommanded to call this function every time a user log out of your application
     # Do not use before a redirect_to because it will not clear the cookies on a redirection
-    def self.intercom_shutdown_helper(cookies)
+    def self.intercom_shutdown_helper(cookies, domain = nil)
       if (cookies.is_a?(ActionDispatch::Cookies::CookieJar))
-        cookies["intercom-session-#{IntercomRails.config.app_id}"] = { value: nil, expires: 1.day.ago}
+        cookies["intercom-session-#{IntercomRails.config.app_id}"] = { value: nil, expires: 1.day.ago }.merge(domain.present? ? { domain: ".#{domain}"} : {})
       else
         controller = cookies
         Rails.logger.info("Warning: IntercomRails::ShutdownHelper.intercom_shutdown_helper takes an instance of ActionDispatch::Cookies::CookieJar as an argument since v0.2.34. Passing a controller is depreciated. See https://github.com/intercom/intercom-rails#shutdown for more details.")
-        controller.response.delete_cookie("intercom-session-#{IntercomRails.config.app_id}", { value: nil, expires: 1.day.ago})
+        controller.response.delete_cookie("intercom-session-#{IntercomRails.config.app_id}", { value: nil, expires: 1.day.ago }).merge(domain.present? ? { domain: ".#{domain}"} : {})
       end
     rescue
     end
@@ -18,10 +18,10 @@ module IntercomRails
       session[:perform_intercom_shutdown] = true
     end
 
-    def self.intercom_shutdown(session, cookies)
+    def self.intercom_shutdown(session, cookies, domain = nil)
       if session[:perform_intercom_shutdown]
         session.delete(:perform_intercom_shutdown)
-        intercom_shutdown_helper(cookies)
+        intercom_shutdown_helper(cookies, domain)
       end
     end
 

--- a/spec/shutdown_helper_spec.rb
+++ b/spec/shutdown_helper_spec.rb
@@ -3,18 +3,36 @@ require 'action_controller'
 
 describe TestController, type: :controller do
   include IntercomRails::ShutdownHelper
-  it 'clears response intercom-session-{app_id} cookie' do
-    IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies)
-    expect(cookies.has_key?('intercom-session-abc123')).to eq true
+  context 'without domain' do
+    it 'clears response intercom-session-{app_id} cookie' do
+      IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies)
+      expect(cookies.has_key?('intercom-session-abc123')).to eq true
+    end
+    it 'creates session[:perform_intercom_shutdown] var' do
+      IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
+      expect(session[:perform_intercom_shutdown]).to eq true
+    end
+    it 'erase intercom cookie, set preform_intercom_shutdown sessions to nil' do
+      session[:perform_intercom_shutdown] = true
+      IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies)
+      expect(session[:perform_intercom_shutdown]).to eq nil
+      expect(cookies.has_key?('intercom-session-abc123')).to eq true
+    end
   end
-  it 'creates session[:perform_intercom_shutdown] var' do
-    IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
-    expect(session[:perform_intercom_shutdown]).to eq true
-  end
-  it 'erase intercom cookie, set preform_intercom_shutdown sessions to nil' do
-    session[:perform_intercom_shutdown] = true
-    IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies)
-    expect(session[:perform_intercom_shutdown]).to eq nil
-    expect(cookies.has_key?('intercom-session-abc123')).to eq true
+  context 'with domain' do
+    it 'clears response intercom-session-{app_id} cookie' do
+      IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies, 'intercom.com')
+      expect(cookies.has_key?('intercom-session-abc123')).to eq true
+    end
+    it 'creates session[:perform_intercom_shutdown] var' do
+      IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
+      expect(session[:perform_intercom_shutdown]).to eq true
+    end
+    it 'erase intercom cookie, set preform_intercom_shutdown sessions to nil' do
+      session[:perform_intercom_shutdown] = true
+      IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies, 'intercom.com')
+      expect(session[:perform_intercom_shutdown]).to eq nil
+      expect(cookies.has_key?('intercom-session-abc123')).to eq true
+    end
   end
 end


### PR DESCRIPTION
This builds on #266, but also handles the case of `localhost`.

As mentioned in #266 and #194, `IntercomRails::ShutdownHelper.intercom_shutdown` does not actually remove the cookie. Meaning folks aren't actually signed out! This happens because the `intercom-session-INTERCOM_ID` cookie is set with a domain value. Thus, we need to include the same value as the `:domain` key when removing the cookie. The [Rails docs say as much](http://api.rubyonrails.org/v5.1/classes/ActionDispatch/Cookies.html)

This PR builds atop @BastienL by also handling the case of `localhost` correctly.

This needs attention 🔜 as it's an open security and privacy issue for all users of `intercom-rails`.