### PR TITLE
include_for_logged_out_users should still work when user excluded

### DIFF
--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -35,7 +35,6 @@ module IntercomRails
     end
 
     def valid?
-      return false if user_details[:excluded_user] == true
       valid = user_details[:app_id].present?
       unless @show_everywhere
         valid = valid && (user_details[:user_id] || user_details[:email]).present?

--- a/spec/auto_include_filter_spec.rb
+++ b/spec/auto_include_filter_spec.rb
@@ -142,6 +142,15 @@ describe TestController, type: :controller do
     IntercomRails.config.include_for_logged_out_users = true
     IntercomRails.config.user.exclude_if = Proc.new {|user| user.email.start_with?('ciaran')}
     get :with_current_user_method
+    expect(response.body).to include('<script id="IntercomSettingsScriptTag">')
+    expect(response.body).not_to include("ciaran@intercom.io")
+    expect(response.body).not_to include("Ciaran Lee")
+  end
+
+  it 'excludes tag entirely if user excluded and logged out users skipped' do
+    IntercomRails.config.include_for_logged_out_users = false
+    IntercomRails.config.user.exclude_if = Proc.new {|user| user.email.start_with?('ciaran')}
+    get :with_current_user_method
     expect(response.body).not_to include('<script id="IntercomSettingsScriptTag">')
     expect(response.body).not_to include("ciaran@intercom.io")
     expect(response.body).not_to include("Ciaran Lee")


### PR DESCRIPTION
Hi Intercom devs! Please let me know what you think of this slight change in functionality.

The current behaviour when you have both `include_for_logged_out_users` and `user.exclude_if` set is a little counter-intuitive. The Intercom dialog appears when you're logged out, and when you're logged in as a valid user, but if you're logged in as an excluded user it disappears.

I'm not sure if there's a use case for this default behaviour, but it seems to make more sense to me to continue showing the `include_for_logged_out_users` Intercom dialog for excluded users, if that option is enabled.

This PR changes that - actually by removing a line from `IntercomRails::ScriptTag`. Excluded users still get no Intercom dialog at all if `include_for_logged_out_users` is false and I've made sure both cases are covered in the tests.

If I've missed your use case, I can make this a separate config option... let me know what works best for you!