### PR TITLE
Improve instructions for deleting users

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,10 +381,10 @@ You can do this using the [intercom-ruby](https://github.com/intercom/intercom-r
 
 ```
 class User
-  after_destroy { DeleteFromIntercom.perform_later(self)
+  after_destroy { DeleteFromIntercomJob.perform_later(self) }
 end
 
-class DeleteFromIntercom < ApplicationJob
+class DeleteFromIntercomJob < ApplicationJob
   def perform(user)
     intercom = Intercom::Client.new
     user = intercom.users.find(id: user.id)


### PR DESCRIPTION
#### Why?
Adds missing closing bracket to "Delete your users" instructions.

#### How?
- Add missing bracket
- Use canonical ActiveJob class name
