### PR TITLE
Corrected a typo with gem version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The easiest way to install Intercom in a rails app.
 
 For interacting with the Intercom REST API, use the `intercom` gem (https://github.com/intercom/intercom-ruby)
 
-Requires ruby 2.0 or higher for `intercom-rails  >= 4.0`
+Requires ruby 2.0 or higher for `intercom-rails  >= 0.4.0`
 
 ## Installation
 Add this to your Gemfile:


### PR DESCRIPTION
#### Why?
While I was trying to configure the behaviour of Intercom in an app, I looked at the README and compared the version of the gem in it and the version I have in the Gemfile.lock.
I wondered where there actually is a version `4.0`.
