### PR TITLE
Use media_type instead of content_type

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -55,7 +55,11 @@ module IntercomRails
       end
 
       def html_content_type?
-        response.content_type == 'text/html'
+        if response.respond_to?(:media_type)
+          response.media_type == 'text/html'
+        else
+          response.content_type == 'text/html'
+        end
       end
 
       def response_has_closing_body_tag?


### PR DESCRIPTION
Fixes https://github.com/intercom/intercom-rails/issues/312.

Rails 6.0.0.rc2 changed the behaviour of the `content_type` method to include the `charset` media type parameter. This broke our content type check, which assumed no parameters would be present. A new `media_type` method was also added that returns the media type without parameters.

We can fix the content type check on Rails 6.0 while staying compatible with older Rails versions by using the `media_type` method if it exists, and falling back to the `content_type` method otherwise.