### PR TITLE
remove rails gemfiles

### DIFF
--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -1,6 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'rails', '~> 3.2.0'
-gem 'test-unit', '~> 3.0'
-
-gemspec :path => '../'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -1,6 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'rails', '~> 4.1.0'
-gem 'mime-types', '2.6.2'
-
-gemspec :path => '../'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,6 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'rails', '~> 4.2.0'
-gem 'mime-types', '2.6.2'
-
-gemspec :path => '../'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -1,9 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'rails', '5.0.0.beta3'
-gem 'sinatra', github: 'sinatra/sinatra'
-
-gem 'rspec', '3.5.0.beta2'
-gem 'rspec-rails', '3.5.0.beta2'
-
-gemspec :path => '../'


### PR DESCRIPTION
#### Why?
they're no longer neccesary since https://github.com/intercom/intercom-rails/commit/7933c86fe232a88306cdd816e0d39d4f8eab6c09
