### PR TITLE
Update URL to find `app_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then run:
 bundle install
 ```
 
-Take note of your `app_id` from [here](https://app.intercom.io/a/apps/_/settings/api-keys) and generate a config file:
+Take note of your `app_id` from [here](https://app.intercom.io/a/apps/_/settings/web) and generate a config file:
 
 ```
 rails generate intercom:config YOUR-APP-ID


### PR DESCRIPTION
### Why?

`https://app.intercom.io/a/apps/_/settings/api-keys` returns "We couldn't find the page you're looking for".

#### How?
This change updates the URL to `settings/web` which has the `app_id` in the script example (I'm not sure if there's a better place to link to?).
