### PR TITLE
Adds access to api_base configuration option

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -108,6 +108,7 @@ module IntercomRails
     config_accessor :enabled_environments, &ARRAY_VALIDATOR
     config_accessor :include_for_logged_out_users
     config_accessor :hide_default_launcher
+    config_accessor :api_base
     config_accessor :encrypted_mode
 
     def self.api_key=(*)

--- a/lib/intercom-rails/encrypted_mode.rb
+++ b/lib/intercom-rails/encrypted_mode.rb
@@ -2,7 +2,7 @@ module IntercomRails
   class EncryptedMode
     attr_reader :secret, :initialization_vector, :enabled
 
-    ENCRYPTED_MODE_SETTINGS_WHITELIST = [:app_id, :session_duration, :widget, :custom_launcher_selector, :hide_default_launcher, :alignment, :horizontal_padding, :vertical_padding]
+    ENCRYPTED_MODE_SETTINGS_WHITELIST = [:app_id, :session_duration, :widget, :custom_launcher_selector, :hide_default_launcher, :api_base, :alignment, :horizontal_padding, :vertical_padding]
 
     def initialize(secret, initialization_vector, options)
       @secret = secret

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -71,6 +71,7 @@ module IntercomRails
       hsh[:widget] = widget_options if widget_options.present?
       hsh[:company] = company_details if company_details.present?
       hsh[:hide_default_launcher] = Config.hide_default_launcher if Config.hide_default_launcher
+      hsh[:api_base] = Config.api_base if Config.api_base
       hsh
     end
 

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -127,4 +127,8 @@ IntercomRails.config do |config|
   #
   # If you'd like to hide default launcher button uncomment this line
   # config.hide_default_launcher = true
+  #
+  # If you need to route your Messenger requests through a different endpoint than the default, replace the below with your app id, and uncomment below line. Generally speaking, this is not needed.
+  # confid.api_base = https://{app_id}.intercom-messenger.com
+  #
 end

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -129,6 +129,6 @@ IntercomRails.config do |config|
   # config.hide_default_launcher = true
   #
   # If you need to route your Messenger requests through a different endpoint than the default, replace the below with your app id, and uncomment below line. Generally speaking, this is not needed.
-  # confid.api_base = https://{app_id}.intercom-messenger.com
+  # config.api_base = https://{app_id}.intercom-messenger.com
   #
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,6 +56,11 @@ describe IntercomRails do
     expect(IntercomRails.config.hide_default_launcher).to eq(true)
   end
 
+  it 'gets/sets api_base' do
+    IntercomRails.config.api_base = "https://abcde1.intercom-messenger.com"
+    expect(IntercomRails.config.api_base).to eq("https://abcde1.intercom-messenger.com")
+  end
+
   it 'gets/sets Encrypted Mode' do
     IntercomRails.config.encrypted_mode = true
     expect(IntercomRails.config.encrypted_mode).to eq(true)

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -150,6 +150,10 @@ describe IntercomRails::ScriptTag do
       IntercomRails.config.hide_default_launcher = true
       expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(true)
     end
+    it 'knows about :api_base' do
+      IntercomRails.config.api_base = "https://abcde1.intercom-messenger.com"
+      expect(ScriptTag.new.intercom_settings['api_base']).to eq("https://abcde1.intercom-messenger.com")
+    end
   end
 
   context 'company' do


### PR DESCRIPTION
#### Why?
Recently an api_base option was added to the Messenger for certain scenarios where the default ping url can't be used.

#### How?
Adds it as an allowed configuration option.
