### PR TITLE
fixes typo on config erb

### DIFF
--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -129,6 +129,6 @@ IntercomRails.config do |config|
   # config.hide_default_launcher = true
   #
   # If you need to route your Messenger requests through a different endpoint than the default, replace the below with your app id, and uncomment below line. Generally speaking, this is not needed.
-  # config.api_base = https://{app_id}.intercom-messenger.com
+  # config.api_base = "https://#{config.app_id}.intercom-messenger.com"
   #
 end

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -128,7 +128,7 @@ IntercomRails.config do |config|
   # If you'd like to hide default launcher button uncomment this line
   # config.hide_default_launcher = true
   #
-  # If you need to route your Messenger requests through a different endpoint than the default, replace the below with your app id, and uncomment below line. Generally speaking, this is not needed.
+  # If you need to route your Messenger requests through a different endpoint than the default, uncomment the below line. Generally speaking, this is not needed.
   # config.api_base = "https://#{config.app_id}.intercom-messenger.com"
   #
 end


### PR DESCRIPTION
#### Why?
Fixes a small typo introduced in https://github.com/intercom/intercom-rails/pull/329 in the config file 

#### How?
Changes the URL to a string and interpolates the app_id to make usage more simple.
