### PR TITLE
Also block controllers inherit from Devise::Passwords controller

### DIFF
--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -14,7 +14,7 @@ module IntercomRails
       BLOCKED_CONTROLLER_NAMES = %w{ Devise::PasswordsController }
 
       def self.filter(controller)
-        return if (BLOCKED_CONTROLLER_NAMES & controller.class.ancestors.map(&:name)).length > 0
+        return if blocked_controller?(controller)
         auto_include_filter = new(controller)
         return unless auto_include_filter.include_javascript?
 
@@ -24,6 +24,10 @@ module IntercomRails
         if defined?(CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook) == 'method'
           CoreExtensions::IntercomRails::AutoInclude.csp_sha256_hook(controller, auto_include_filter.csp_sha256)
         end
+      end
+
+      def self.blocked_controller?(controller)
+        (BLOCKED_CONTROLLER_NAMES & controller.class.ancestors.map(&:name)).length > 0
       end
 
       attr_reader :controller

--- a/lib/intercom-rails/auto_include_filter.rb
+++ b/lib/intercom-rails/auto_include_filter.rb
@@ -14,7 +14,7 @@ module IntercomRails
       BLOCKED_CONTROLLER_NAMES = %w{ Devise::PasswordsController }
 
       def self.filter(controller)
-        return if BLOCKED_CONTROLLER_NAMES.include?(controller.class.name)
+        return if (BLOCKED_CONTROLLER_NAMES & controller.class.ancestors.map(&:name)).length > 0
         auto_include_filter = new(controller)
         return unless auto_include_filter.include_javascript?
 


### PR DESCRIPTION
#### Why?
Sometime we need to customise some logic of devise, which usually done via inheritance of Devise::Passwords controller. However, the script would get injected because the class name is no longer `Devise::PasswordsController`


#### How?
This fix checks all the ancestors of the current controller and intersect with BLOCKED controller names, and block when there is positive count. 

Alternatively, we could use `superclass.name` instead of `class.ancestors.map(&:name)`, however this is limited to only 1 level of inheritance from `Devise::PasswordsController`
