### PR TITLE
Add callback method in controller when auto include filter decides not to insert javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ By default Intercom will be automatically inserted in development and production
   config.enabled_environments = ["production"]
 ```
 
+### Controller callback
+
+When using automatic insertion of Intercom Javascript, you can have a callback method in your controller should the criteria to automatically insert javascript is unmet. The callback is `intercom_javascript_excluded` by default, but you can configure to a more appropriate name for all controllers in your application.
+
+```ruby
+  config.exclude_javascript_callback = :intercom_javascript_excluded
+```
+
 ### Manually Inserting the Intercom Javascript
 
 Some situations may require manually inserting the Intercom script tag. If you simply wish to place the Intercom javascript in a different place within the page or, on a page without a closing `</body>` tag:

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -110,6 +110,7 @@ module IntercomRails
     config_accessor :hide_default_launcher
     config_accessor :api_base
     config_accessor :encrypted_mode
+    config_accessor :exclude_javascript_callback
 
     def self.api_key=(*)
       warn "Setting an Intercom API key is no longer supported; remove the `config.api_key = ...` line from config/initializers/intercom.rb"

--- a/spec/auto_include_filter_spec.rb
+++ b/spec/auto_include_filter_spec.rb
@@ -255,4 +255,11 @@ describe TestController, type: :controller do
       expect(response.body).to include('nonce="aaaa"')
     end
   end
+
+  context 'when intercom script is not injected' do
+    it 'invokes callback on controller' do
+      expect(controller).to receive(:intercom_javascript_excluded)
+      get :without_user
+    end
+  end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -66,6 +66,11 @@ describe IntercomRails do
     expect(IntercomRails.config.encrypted_mode).to eq(true)
   end
 
+  it 'gets/sets controller callback' do
+    IntercomRails.config.exclude_javascript_callback = :callback
+    expect(IntercomRails.config.exclude_javascript_callback).to eq(:callback)
+  end
+
   it 'raises error if current user not a proc' do
     expect { IntercomRails.config.user.current = 1 }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
#### Why?

We have lots of javascript code that blindly invokes `window.Intercom(...)` expecting that it's a function. The assumption that `window.Intercom` is always a function breaks down, when `IntercomRails::AutoInclude::Filter` is evaluated to exclude javascript, which results in JS runtime error.

#### How?

This PR adds a configurable callback method on a controller for case when `IntercomRails::AutoInclude::Filter` excludes javascript. Within the controller callback, a shim can be added to ensure that `window.Intercom` is indeed a function.