### PR TITLE
Add alignment options to widget settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ You can customize the CSS selector, by setting
   config.inbox.custom_activator = '.intercom-link'
 ```
 
+You can choose widget alignment, by setting
+
+```ruby
+  config.alignment = :left
+```
+
 You can hide default launcher button, by setting
 
 ```ruby

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -108,6 +108,7 @@ module IntercomRails
     config_accessor :enabled_environments, &ARRAY_VALIDATOR
     config_accessor :include_for_logged_out_users
     config_accessor :hide_default_launcher
+    config_accessor :alignment
     config_accessor :api_base
     config_accessor :encrypted_mode
 

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -71,6 +71,7 @@ module IntercomRails
       hsh[:widget] = widget_options if widget_options.present?
       hsh[:company] = company_details if company_details.present?
       hsh[:hide_default_launcher] = Config.hide_default_launcher if Config.hide_default_launcher
+      hsh[:alignment] = Config.alignment if Config.alignment
       hsh[:api_base] = Config.api_base if Config.api_base
       hsh
     end

--- a/lib/rails/generators/intercom/config/intercom.rb.erb
+++ b/lib/rails/generators/intercom/config/intercom.rb.erb
@@ -119,6 +119,8 @@ IntercomRails.config do |config|
   # open the messenger.
   #
   # config.inbox.style = :custom
+
+  # config.alignment = :left
   #
   # If you'd like to use your own link activator CSS selector
   # uncomment this line and clicks on any element that matches the query will

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,6 +56,11 @@ describe IntercomRails do
     expect(IntercomRails.config.hide_default_launcher).to eq(true)
   end
 
+  it 'gets/sets alignment' do
+    IntercomRails.config.alignment = :left
+    expect(IntercomRails.config.alignment).to eq(:left)
+  end
+
   it 'gets/sets api_base' do
     IntercomRails.config.api_base = "https://abcde1.intercom-messenger.com"
     expect(IntercomRails.config.api_base).to eq("https://abcde1.intercom-messenger.com")

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -146,6 +146,10 @@ describe IntercomRails::ScriptTag do
       IntercomRails.config.inbox.custom_activator = '.intercom'
       expect(ScriptTag.new.intercom_settings['widget']).to eq({'activator' => '.intercom'})
     end
+    it 'knows about :alignment' do
+      IntercomRails.config.alignment = :left
+      expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(:left)
+    end
     it 'knows about :hide_default_launcher' do
       IntercomRails.config.hide_default_launcher = true
       expect(ScriptTag.new.intercom_settings['hide_default_launcher']).to eq(true)


### PR DESCRIPTION
#### Why?
I want to be able to set alignment on the inbox widget. Fixes #287 

#### How?
Added option to set `alignment` in the initializer and it would be added to the script tag.
