### PR TITLE
Provide installation type as settings attribute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5.7
+      - image: cimg/ruby:2.7
 
     working_directory: ~/intercom-rails
 

--- a/intercom-rails.gemspec
+++ b/intercom-rails.gemspec
@@ -18,14 +18,15 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'activesupport', '>3.0'
+  s.add_dependency 'activesupport', '>4.0'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'actionpack', '>3.2.12'
-  s.add_development_dependency 'rspec', '~> 3.1'
-  s.add_development_dependency 'rspec-rails', '~> 3.1'
+  s.add_development_dependency 'actionpack', '>5.0'
+  s.add_development_dependency 'rspec', '~> 3.13'
+  s.add_development_dependency 'rspec-rails', '~> 5.0'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'sinatra', '~> 1.4.5'
+  s.add_development_dependency 'sinatra', '~> 2.0'
   s.add_development_dependency 'thin', '~> 1.7.0'
+  s.add_development_dependency 'bigdecimal', '1.3.5'
   s.add_development_dependency 'tzinfo'
   s.add_development_dependency 'gem-release'
 end

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/json'
-require 'active_support/core_ext/hash/indifferent_access'
-require 'active_support/core_ext/string/output_safety'
+require 'active_support/all'
 require 'action_view'
 
 module IntercomRails

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -72,6 +72,7 @@ module IntercomRails
       hsh[:company] = company_details if company_details.present?
       hsh[:hide_default_launcher] = Config.hide_default_launcher if Config.hide_default_launcher
       hsh[:api_base] = Config.api_base if Config.api_base
+      hsh[:installation_type] = 'rails'
       hsh
     end
 

--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "0.4.3"
+  VERSION = "1.0.0"
 end

--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -35,7 +35,7 @@ describe IntercomRails::ScriptTagHelper do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
+      expect(script_tag.csp_sha256).to eq("'sha256-lOGcYryJDhf1KCboXuy8wxCxIGAT16HDiUQNRhluxRQ='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -206,7 +206,7 @@ describe IntercomRails::ScriptTag do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-qLRbekKD6dEDMyLKPNFYpokzwYCz+WeNPqJE603mT24='")
+      expect(script_tag.csp_sha256).to eq("'sha256-lOGcYryJDhf1KCboXuy8wxCxIGAT16HDiUQNRhluxRQ='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -37,6 +37,13 @@ describe IntercomRails::ScriptTag do
     end
   end
 
+  context 'integration type' do
+    it 'should be rails' do
+      script_tag = ScriptTag.new()
+      expect(script_tag.intercom_settings[:installation_type]).to eq('rails')
+    end
+  end
+
   it 'strips out nil entries for standard attributes' do
     %w(name email user_id).each do |standard_attribute|
       with_value = ScriptTag.new(:user_details => {standard_attribute => 'value'})


### PR DESCRIPTION
#### Why?
We want to better understand how people usually install our messenger. For that reason on all non snippet installations we set `installation_type` settings attribute that will provide that information.

## Evidence

<img width="758" alt="Screenshot 2024-02-12 at 10 55 54" src="https://github.com/intercom/intercom-rails/assets/4772270/5af91d31-e5e3-4291-85f1-692794ae5ab8">
