### PR TITLE
Insert script immediately if loaded with Turbo

### DIFF
--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -110,7 +110,7 @@ module IntercomRails
       plaintext_javascript = ActiveSupport::JSON.encode(plaintext_settings).gsub('<', '\u003C')
       intercom_encrypted_payload_javascript = encrypted_mode.encrypted_javascript(intercom_settings)
 
-      "window.intercomSettings = #{plaintext_javascript};#{intercom_encrypted_payload_javascript}(function(){var w=window;var ic=w.Intercom;if(typeof ic===\"function\"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='#{Config.library_url || "https://widget.intercom.io/widget/#{j app_id}"}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}};})()"
+      "window.intercomSettings = #{plaintext_javascript};#{intercom_encrypted_payload_javascript}(function(){var w=window;var ic=w.Intercom;if(typeof ic===\"function\"){ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='#{Config.library_url || "https://widget.intercom.io/widget/#{j app_id}"}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}};})()"
     end
 
     def user_details=(user_details)

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -110,7 +110,7 @@ module IntercomRails
       plaintext_javascript = ActiveSupport::JSON.encode(plaintext_settings).gsub('<', '\u003C')
       intercom_encrypted_payload_javascript = encrypted_mode.encrypted_javascript(intercom_settings)
 
-      "window.intercomSettings = #{plaintext_javascript};#{intercom_encrypted_payload_javascript}(function(){var w=window;var ic=w.Intercom;if(typeof ic===\"function\"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='#{Config.library_url || "https://widget.intercom.io/widget/#{j app_id}"}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}};})()"
+      "window.intercomSettings = #{plaintext_javascript};#{intercom_encrypted_payload_javascript}(function(){var w=window;var ic=w.Intercom;if(typeof ic===\"function\"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='#{Config.library_url || "https://widget.intercom.io/widget/#{j app_id}"}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}};})()"
     end
 
     def user_details=(user_details)

--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -35,7 +35,7 @@ describe IntercomRails::ScriptTagHelper do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-lOGcYryJDhf1KCboXuy8wxCxIGAT16HDiUQNRhluxRQ='")
+      expect(script_tag.csp_sha256).to eq("'sha256-b7BLDzBRCLBZQHiI/9zGeyIYpnzQ7u17uV6cTv5rlAA='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -35,7 +35,7 @@ describe IntercomRails::ScriptTagHelper do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-b7BLDzBRCLBZQHiI/9zGeyIYpnzQ7u17uV6cTv5rlAA='")
+      expect(script_tag.csp_sha256).to eq("'sha256-/0mStQPBID1jSuXAoW0YtDqu8JmWUJJ5SdBB2u7Fy90='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -206,7 +206,7 @@ describe IntercomRails::ScriptTag do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-lOGcYryJDhf1KCboXuy8wxCxIGAT16HDiUQNRhluxRQ='")
+      expect(script_tag.csp_sha256).to eq("'sha256-b7BLDzBRCLBZQHiI/9zGeyIYpnzQ7u17uV6cTv5rlAA='")
     end
 
     it 'inserts a valid nonce if present' do

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -206,7 +206,7 @@ describe IntercomRails::ScriptTag do
         :email => 'marco@intercom.io',
         :user_id => 'marco',
       })
-      expect(script_tag.csp_sha256).to eq("'sha256-b7BLDzBRCLBZQHiI/9zGeyIYpnzQ7u17uV6cTv5rlAA='")
+      expect(script_tag.csp_sha256).to eq("'sha256-/0mStQPBID1jSuXAoW0YtDqu8JmWUJJ5SdBB2u7Fy90='")
     end
 
     it 'inserts a valid nonce if present' do


### PR DESCRIPTION
For https://github.com/intercom/intercom-rails/issues/351.

When the Messenger shim is loaded with Turbo, the load event has already fired, so adding an event listener for it won't have any effect. Instead we can immediately add the script tag to the page.

Also stop calling `Intercom('reattach_activator')`, which is an obsolete API that no longer does anything.