### PR TITLE
Support experimental JWT feature (not available yet)

### DIFF
--- a/intercom-rails.gemspec
+++ b/intercom-rails.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'activesupport', '>4.0'
+  s.add_dependency 'jwt', '~> 2.0'
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'actionpack', '>5.0'
   s.add_development_dependency 'rspec', '~> 3.13'
   s.add_development_dependency 'rspec-rails', '~> 5.0'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'sinatra', '~> 2.0'
-  s.add_development_dependency 'thin', '~> 1.7.0'
-  s.add_development_dependency 'bigdecimal', '1.3.5'
+  s.add_development_dependency 'sinatra', '~> 3.0'
   s.add_development_dependency 'tzinfo'
   s.add_development_dependency 'gem-release'
 end

--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -110,6 +110,7 @@ module IntercomRails
     config_accessor :hide_default_launcher
     config_accessor :api_base
     config_accessor :encrypted_mode
+    config_accessor :jwt_enabled
 
     def self.api_key=(*)
       warn "Setting an Intercom API key is no longer supported; remove the `config.api_key = ...` line from config/initializers/intercom.rb"

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -134,6 +134,7 @@ module IntercomRails
         if secret.present?
           if jwt_enabled && u[:user_id].present?
             u[:intercom_user_jwt] ||= generate_jwt
+            u.delete(:user_id)  # No need to send plaintext user_id when using JWT
           elsif (u[:user_id] || u[:email]).present?
             u[:user_hash] ||= user_hash
           end

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/all'
 require 'action_view'
+require 'jwt'
 
 module IntercomRails
 
@@ -17,7 +18,7 @@ module IntercomRails
     include ::ActionView::Helpers::TagHelper
 
     attr_reader :user_details, :company_details, :show_everywhere, :session_duration
-    attr_accessor :secret, :widget_options, :controller, :nonce, :encrypted_mode_enabled, :encrypted_mode
+    attr_accessor :secret, :widget_options, :controller, :nonce, :encrypted_mode_enabled, :encrypted_mode, :jwt_enabled
 
     def initialize(options = {})
       self.secret = options[:secret] || Config.api_secret
@@ -25,6 +26,8 @@ module IntercomRails
       self.controller = options[:controller]
       @show_everywhere = options[:show_everywhere]
       @session_duration = session_duration_from_config
+      self.jwt_enabled = options[:jwt_enabled] || Config.jwt_enabled
+
       self.user_details = options[:find_current_user_details] ? find_current_user_details : options[:user_details]
 
       self.encrypted_mode_enabled = options[:encrypted_mode] || Config.encrypted_mode
@@ -113,12 +116,29 @@ module IntercomRails
       "window.intercomSettings = #{plaintext_javascript};#{intercom_encrypted_payload_javascript}(function(){var w=window;var ic=w.Intercom;if(typeof ic===\"function\"){ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='#{Config.library_url || "https://widget.intercom.io/widget/#{j app_id}"}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}};})()"
     end
 
+    def generate_jwt
+      return nil unless user_details[:user_id].present?
+      
+      payload = {
+        user_id: user_details[:user_id].to_s,
+        exp: 24.hours.from_now.to_i
+      }
+      JWT.encode(payload, secret, 'HS256')
+    end
+
     def user_details=(user_details)
       @user_details = DateHelper.convert_dates_to_unix_timestamps(user_details || {})
       @user_details = @user_details.with_indifferent_access.tap do |u|
         [:email, :name, :user_id].each { |k| u.delete(k) if u[k].nil? }
 
-        u[:user_hash] ||= user_hash if secret.present? && (u[:user_id] || u[:email]).present?
+        if secret.present?
+          if jwt_enabled && u[:user_id].present?
+            u[:intercom_user_jwt] ||= generate_jwt
+          elsif (u[:user_id] || u[:email]).present?
+            u[:user_hash] ||= user_hash
+          end
+        end
+        
         u[:app_id] ||= app_id
       end
     end

--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -114,4 +114,21 @@ describe IntercomRails do
       IntercomRails.config.user.company_association = Proc.new { [] }
     end.to output(/no longer supported/).to_stderr
   end
+
+  it 'gets/sets jwt_enabled' do
+    IntercomRails.config.jwt_enabled = true
+    expect(IntercomRails.config.jwt_enabled).to eq(true)
+  end
+
+  it 'defaults jwt_enabled to nil' do
+    IntercomRails.config.reset!
+    expect(IntercomRails.config.jwt_enabled).to eq(nil)
+  end
+
+  it 'allows jwt_enabled in block form' do
+    IntercomRails.config do |config|
+      config.jwt_enabled = true
+    end
+    expect(IntercomRails.config.jwt_enabled).to eq(true)
+  end
 end

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -49,4 +49,35 @@ describe IntercomRails::ScriptTagHelper do
       expect(script_tag.to_s).to include('nonce="pJwtLVnwiMaPCxpb41KZguOcC5mGUYD+8RNGcJSlR94="')
     end
   end
+
+  context 'JWT authentication' do
+    before(:each) do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
+    end
+    before(:each) do
+      IntercomRails.config.api_secret = 'super-secret'
+    end
+
+    it 'enables JWT when configured' do
+      IntercomRails.config.jwt_enabled = true
+      output = intercom_script_tag({
+        user_id: '1234',
+        email: 'test@example.com'
+      }).to_s
+    
+      expect(output).to include('intercom_user_jwt')
+      expect(output).not_to include('user_hash')
+    end
+
+    it 'falls back to user_hash when JWT is disabled' do
+      IntercomRails.config.jwt_enabled = false
+      output = intercom_script_tag({
+        user_id: '1234',
+        email: 'test@example.com'
+      }).to_s
+      
+      expect(output).not_to include('intercom_user_jwt')
+      expect(output).to include('user_hash')
+    end
+  end
 end

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -1,5 +1,6 @@
 require 'active_support/time'
 require 'spec_helper'
+require 'jwt'
 
 describe IntercomRails::ScriptTag do
   ScriptTag = IntercomRails::ScriptTag
@@ -264,6 +265,68 @@ describe IntercomRails::ScriptTag do
       expect(script_tag.intercom_settings[:ad_data]).to eq(nil)
     end
 
+  end
+
+  context 'JWT authentication' do
+    before(:each) do
+      IntercomRails.config.app_id = 'jwt_test'
+      IntercomRails.config.api_secret = 'super-secret'
+    end
+
+    it 'does not include JWT when jwt_enabled is false' do
+      script_tag = ScriptTag.new(
+        user_details: { user_id: '1234' },
+        jwt_enabled: false
+      )
+      expect(script_tag.intercom_settings[:intercom_user_jwt]).to be_nil
+    end
+
+    it 'includes JWT when jwt_enabled is true' do
+      script_tag = ScriptTag.new(
+        user_details: { user_id: '1234' },
+        jwt_enabled: true
+      )
+      expect(script_tag.intercom_settings[:intercom_user_jwt]).to be_present
+    end
+
+    it 'does not include user_hash when JWT is enabled' do
+      script_tag = ScriptTag.new(
+        user_details: { user_id: '1234' },
+        jwt_enabled: true
+      )
+      expect(script_tag.intercom_settings[:user_hash]).to be_nil
+    end
+
+    it 'generates a valid JWT with correct payload' do
+      user_id = '1234'
+      script_tag = ScriptTag.new(
+        user_details: { user_id: user_id },
+        jwt_enabled: true
+      )
+      
+      jwt = script_tag.intercom_settings[:intercom_user_jwt]
+      decoded_payload = JWT.decode(jwt, 'super-secret', true, { algorithm: 'HS256' })[0]
+      
+      expect(decoded_payload['user_id']).to eq(user_id)
+      expect(decoded_payload['exp']).to be_within(5).of(24.hours.from_now.to_i)
+    end
+
+    it 'does not generate JWT when user_id is missing' do
+      script_tag = ScriptTag.new(
+        user_details: { email: 'test@example.com' },
+        jwt_enabled: true
+      )
+      expect(script_tag.intercom_settings[:intercom_user_jwt]).to be_nil
+    end
+
+    it 'does not generate JWT when api_secret is missing' do
+      IntercomRails.config.api_secret = nil
+      script_tag = ScriptTag.new(
+        user_details: { user_id: '1234' },
+        jwt_enabled: true
+      )
+      expect(script_tag.intercom_settings[:intercom_user_jwt]).to be_nil
+    end
   end
 
 end

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -327,6 +327,37 @@ describe IntercomRails::ScriptTag do
       )
       expect(script_tag.intercom_settings[:intercom_user_jwt]).to be_nil
     end
+
+    it 'removes user_id from payload when using JWT' do
+      script_tag = ScriptTag.new(
+        user_details: { 
+          user_id: '1234',
+          email: 'test@example.com',
+          name: 'Test User'
+        },
+        jwt_enabled: true
+      )
+      
+      expect(script_tag.intercom_settings[:intercom_user_jwt]).to be_present
+      expect(script_tag.intercom_settings[:user_id]).to be_nil
+      expect(script_tag.intercom_settings[:email]).to eq('test@example.com')
+      expect(script_tag.intercom_settings[:name]).to eq('Test User')
+    end
+
+    it 'keeps user_id in payload when not using JWT' do
+      script_tag = ScriptTag.new(
+        user_details: { 
+          user_id: '1234',
+          email: 'test@example.com',
+          name: 'Test User'
+        },
+        jwt_enabled: false
+      )
+      
+      expect(script_tag.intercom_settings[:user_id]).to eq('1234')
+      expect(script_tag.intercom_settings[:email]).to eq('test@example.com')
+      expect(script_tag.intercom_settings[:name]).to eq('Test User')
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'intercom-rails'
 require 'rspec'
 require 'active_support/core_ext/string/output_safety'
+require 'pry'
 
 def dummy_user(options = {})
   user = Struct.new(:email, :name).new


### PR DESCRIPTION
We're working on an experimental feature to allow you to authenticate with the messenger using a JWT token instead of sending a user_hash. 

**This feature is not currently general release** however we will be seeking beta customers early next year (2025). If you are interested drop us a line at security@intercom.com (even if you don't use the rails gem!)

### Description of the feature
When launching the Messenger for a logged-in User, you can provide a signed JSON Web Token in the intercom_user_jwt attribute of the Messenger payload. 

This JWT can contain any User Data Attributes you want to securely send for the user. If you want to ensure those attributes can only be updated by you, you should [disable Messenger updates](https://www.intercom.com/help/en/articles/179-create-and-track-custom-data-attributes-cdas#h_05e4ed1432) for these Attributes, and as long as they are signed, they will still be updated.

You can use [industry standard JWT libraries](https://jwt.io/libraries) to generate the token, using your Messenger API Secret as the secret key.

A Messenger installation with JWTs requires minimal change compared to basic Identity Verification.

Example Server-Side Configuration
```
var jwt = require('jsonwebtoken');
const intercomUserJwt = jwt.sign({ user_id: '123', email: 'user@email.com', phone: '345-345-3456' }, '<API_SECRET>', { expiresIn: '1h' });
```

Example Client-Side Configuration
```
<script>
    window.intercomSettings = {
      app_id: <APP_ID_CODE>,
      intercom_user_jwt: <TOKEN>,
      extra_data_attribute: 'data'
    };
</script>
```

### TODO
JWT also supports signing CDAs, will add a separate PR for that. Once we do that we probably shouldn't send any of those attributes in the clear as part of the user_data either (especially email and phone)
