### PR TITLE
Fix double initialization of user authentication in ScriptTag

### DIFF
--- a/intercom-rails.gemspec
+++ b/intercom-rails.gemspec
@@ -19,14 +19,13 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'activesupport', '>4.0'
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'actionpack', '>5.0'
   s.add_development_dependency 'rspec', '~> 3.13'
   s.add_development_dependency 'rspec-rails', '~> 5.0'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'sinatra', '~> 2.0'
-  s.add_development_dependency 'thin', '~> 1.7.0'
-  s.add_development_dependency 'bigdecimal', '1.3.5'
+  s.add_development_dependency 'sinatra', '~> 3.0'
   s.add_development_dependency 'tzinfo'
   s.add_development_dependency 'gem-release'
 end

--- a/lib/intercom-rails/script_tag.rb
+++ b/lib/intercom-rails/script_tag.rb
@@ -25,13 +25,19 @@ module IntercomRails
       self.controller = options[:controller]
       @show_everywhere = options[:show_everywhere]
       @session_duration = session_duration_from_config
-      self.user_details = options[:find_current_user_details] ? find_current_user_details : options[:user_details]
+    
+      initial_user_details = if options[:find_current_user_details]
+        find_current_user_details
+      else
+        options[:user_details] || {}
+      end
+
+      lead_attributes = find_lead_attributes
+
+      self.user_details = initial_user_details.merge(lead_attributes)
 
       self.encrypted_mode_enabled = options[:encrypted_mode] || Config.encrypted_mode
       self.encrypted_mode = IntercomRails::EncryptedMode.new(secret, options[:initialization_vector], {:enabled => encrypted_mode_enabled})
-
-      # Request specific custom data for non-signed up users base on lead_attributes
-      self.user_details = self.user_details.merge(find_lead_attributes)
 
       self.company_details = if options[:find_current_company_details]
         find_current_company_details

--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/script_tag_spec.rb
+++ b/spec/script_tag_spec.rb
@@ -263,7 +263,42 @@ describe IntercomRails::ScriptTag do
       # Rejects
       expect(script_tag.intercom_settings[:ad_data]).to eq(nil)
     end
+  end
 
+  context 'with lead attributes' do
+    before do
+      IntercomRails.config.user.lead_attributes = [:plan]
+      IntercomRails.config.api_secret = 'abcdefgh'
+      allow_any_instance_of(IntercomRails::ScriptTag).to receive(:controller).and_return(
+        double(intercom_custom_data: double(user: { 'plan' => 'pro' }))
+      )
+    end
+
+    it 'merges lead attributes with user details' do
+      script_tag = ScriptTag.new(
+        user_details: { 
+          user_id: '1234',
+          name: 'Test User'
+        }
+      )
+
+      expect(script_tag.intercom_settings[:plan]).to eq('pro')
+      expect(script_tag.intercom_settings[:user_hash]).to be_present
+    end
+
+    it 'preserves existing user details when merging lead attributes' do
+      script_tag = ScriptTag.new(
+        user_details: { 
+          user_id: '1234',
+          name: 'Test User',
+          email: 'test@example.com'
+        }
+      )
+
+      expect(script_tag.intercom_settings[:plan]).to eq('pro')
+      expect(script_tag.intercom_settings[:name]).to eq('Test User')
+      expect(script_tag.intercom_settings[:email]).to eq('test@example.com')
+    end
   end
 
 end


### PR DESCRIPTION
When initializing ScriptTag, we were calling user_details= twice:
once for initial user details and again when merging lead attributes.

In https://github.com/intercom/intercom-rails/pull/356, this caused both JWT and user_hash to be included in the settings
when only one should be present (because we delete the user_id from the unsigned payload - so we end up doing user_hash on the email address the 2nd time around)