### PR TITLE
Support signing data attributes with JWT

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -110,7 +110,6 @@ module IntercomRails
     config_accessor :hide_default_launcher
     config_accessor :api_base
     config_accessor :encrypted_mode
-    config_accessor :jwt_enabled
 
     def self.api_key=(*)
       warn "Setting an Intercom API key is no longer supported; remove the `config.api_key = ...` line from config/initializers/intercom.rb"
@@ -141,6 +140,15 @@ module IntercomRails
       config_accessor :custom_activator
       config_accessor :style do |value|
         raise ArgumentError, "inbox.style must be one of :default or :custom" unless [:default, :custom].include?(value)
+      end
+    end
+
+    config_group :jwt do
+      config_accessor :enabled
+      config_accessor :signed_user_fields do |value|
+        unless value.nil? || (value.kind_of?(Array) && value.all? { |v| v.kind_of?(Symbol) || v.kind_of?(String) })
+          raise ArgumentError, "jwt.signed_user_fields must be an array of symbols or strings"
+        end
       end
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -115,20 +115,48 @@ describe IntercomRails do
     end.to output(/no longer supported/).to_stderr
   end
 
-  it 'gets/sets jwt_enabled' do
-    IntercomRails.config.jwt_enabled = true
-    expect(IntercomRails.config.jwt_enabled).to eq(true)
-  end
+  context 'jwt configuration' do
 
-  it 'defaults jwt_enabled to nil' do
-    IntercomRails.config.reset!
-    expect(IntercomRails.config.jwt_enabled).to eq(nil)
-  end
-
-  it 'allows jwt_enabled in block form' do
-    IntercomRails.config do |config|
-      config.jwt_enabled = true
+    it 'gets/sets jwt_enabled' do
+      IntercomRails.config.jwt.enabled = true
+      expect(IntercomRails.config.jwt.enabled).to eq(true)
     end
-    expect(IntercomRails.config.jwt_enabled).to eq(true)
+
+    it 'defaults jwt_enabled to nil' do
+      IntercomRails.config.reset!
+      expect(IntercomRails.config.jwt.enabled).to eq(nil)
+    end
+
+    it 'allows jwt_enabled in block form' do
+      IntercomRails.config do |config|
+        config.jwt.enabled = true
+      end
+      expect(IntercomRails.config.jwt.enabled).to eq(true)
+    end\
+
+    it 'gets/sets signed_user_fields' do
+      IntercomRails.config.jwt.signed_user_fields = [:email, :name]
+      expect(IntercomRails.config.jwt.signed_user_fields).to eq([:email, :name])
+    end
+
+    it 'validates signed_user_fields is an array of symbols or strings' do
+      expect { 
+        IntercomRails.config.jwt.signed_user_fields = "not_an_array"
+      }.to raise_error(ArgumentError)
+
+      expect { 
+        IntercomRails.config.jwt.signed_user_fields = [1, 2, 3]
+      }.to raise_error(ArgumentError)
+
+      expect { 
+        IntercomRails.config.jwt.signed_user_fields = [:email, "name", :custom_field]
+      }.not_to raise_error
+    end
+
+    it 'allows nil signed_user_fields' do
+      expect { 
+        IntercomRails.config.jwt.signed_user_fields = nil
+      }.not_to raise_error
+    end
   end
 end

--- a/spec/script_tag_helper_spec.rb
+++ b/spec/script_tag_helper_spec.rb
@@ -59,7 +59,7 @@ describe IntercomRails::ScriptTagHelper do
     end
 
     it 'enables JWT when configured' do
-      IntercomRails.config.jwt_enabled = true
+      IntercomRails.config.jwt.enabled = true
       output = intercom_script_tag({
         user_id: '1234',
         email: 'test@example.com'
@@ -70,7 +70,7 @@ describe IntercomRails::ScriptTagHelper do
     end
 
     it 'falls back to user_hash when JWT is disabled' do
-      IntercomRails.config.jwt_enabled = false
+      IntercomRails.config.jwt.enabled = false
       output = intercom_script_tag({
         user_id: '1234',
         email: 'test@example.com'


### PR DESCRIPTION
Follow on from https://github.com/intercom/intercom-rails/pull/356 to also support signing data attributes with the JWT. The plan would be to allow these to bypass attribute protection so they can be updated by the messenger (and not directly by an end user interacting with their browser console)