### PR TITLE
Bump intercom-rails to 1.0.4

### DIFF
--- a/lib/intercom-rails/version.rb
+++ b/lib/intercom-rails/version.rb
@@ -1,3 +1,3 @@
 module IntercomRails
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
The version released on rubygems - https://rubygems.org/gems/intercom-rails/versions

I don't have permission to push to master here so this commit was just floating in the ether. 