### PR TITLE
Optionally support expiry of JWTs

### DIFF
--- a/lib/intercom-rails/config.rb
+++ b/lib/intercom-rails/config.rb
@@ -145,6 +145,7 @@ module IntercomRails
 
     config_group :jwt do
       config_accessor :enabled
+      config_accessor :expiry
       config_accessor :signed_user_fields do |value|
         unless value.nil? || (value.kind_of?(Array) && value.all? { |v| v.kind_of?(Symbol) || v.kind_of?(String) })
           raise ArgumentError, "jwt.signed_user_fields must be an array of symbols or strings"


### PR DESCRIPTION
Originally we had the expiry hardcoded, however we are going to allow expiry to be an optional thing customers can adopt if they want. It's more secure but it does come with some functional risk (i.e. if users do not reload the page and get a fresh JWT requests may start to fail if there is a short expiry). 