### PR TITLE
Require domain parameter for Intercom cookie deletion

### DIFF
--- a/spec/shutdown_helper_spec.rb
+++ b/spec/shutdown_helper_spec.rb
@@ -3,36 +3,42 @@ require 'action_controller'
 
 describe TestController, type: :controller do
   include IntercomRails::ShutdownHelper
-  context 'without domain' do
-    it 'clears response intercom-session-{app_id} cookie' do
-      IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies)
-      expect(cookies.has_key?('intercom-session-abc123')).to eq true
-    end
-    it 'creates session[:perform_intercom_shutdown] var' do
-      IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
-      expect(session[:perform_intercom_shutdown]).to eq true
-    end
-    it 'erase intercom cookie, set preform_intercom_shutdown sessions to nil' do
-      session[:perform_intercom_shutdown] = true
-      IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies)
-      expect(session[:perform_intercom_shutdown]).to eq nil
-      expect(cookies.has_key?('intercom-session-abc123')).to eq true
-    end
+  it 'clears response intercom-session-{app_id} cookie' do
+    IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies, 'intercom.com')
+    expect(cookies.has_key?('intercom-session-abc123')).to eq true
   end
-  context 'with domain' do
-    it 'clears response intercom-session-{app_id} cookie' do
-      IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies, 'intercom.com')
-      expect(cookies.has_key?('intercom-session-abc123')).to eq true
-    end
-    it 'creates session[:perform_intercom_shutdown] var' do
-      IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
-      expect(session[:perform_intercom_shutdown]).to eq true
-    end
-    it 'erase intercom cookie, set preform_intercom_shutdown sessions to nil' do
-      session[:perform_intercom_shutdown] = true
-      IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies, 'intercom.com')
-      expect(session[:perform_intercom_shutdown]).to eq nil
-      expect(cookies.has_key?('intercom-session-abc123')).to eq true
-    end
+  it 'creates session[:perform_intercom_shutdown] var' do
+    IntercomRails::ShutdownHelper.prepare_intercom_shutdown(session)
+    expect(session[:perform_intercom_shutdown]).to eq true
+  end
+  it 'erase intercom cookie, set preform_intercom_shutdown sessions to nil' do
+    session[:perform_intercom_shutdown] = true
+    IntercomRails::ShutdownHelper.intercom_shutdown(session, cookies, 'intercom.com')
+    expect(session[:perform_intercom_shutdown]).to eq nil
+    expect(cookies.has_key?('intercom-session-abc123')).to eq true
+  end
+  it 'adds a leading dot to the domain if not present' do
+    allow(cookies).to receive(:[]=)
+    IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies, 'intercom.com')
+    expect(cookies).to have_received(:[]=).with(
+      "intercom-session-#{IntercomRails.config.app_id}",
+      hash_including(domain: '.intercom.com')
+    )
+  end
+  it 'keeps the domain as is if it already has a leading dot' do
+    allow(cookies).to receive(:[]=)
+    IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies, '.intercom.com')
+    expect(cookies).to have_received(:[]=).with(
+      "intercom-session-#{IntercomRails.config.app_id}",
+      hash_including(domain: '.intercom.com')
+    )
+  end
+  it 'handles localhost domain specially' do
+    allow(cookies).to receive(:[]=)
+    IntercomRails::ShutdownHelper.intercom_shutdown_helper(cookies, 'localhost')
+    expect(cookies).to have_received(:[]=).with(
+      "intercom-session-#{IntercomRails.config.app_id}",
+      hash_not_including(domain: anything)
+    )
   end
 end


### PR DESCRIPTION
This change makes the domain parameter required in both intercom_shutdown_helper and intercom_shutdown methods to ensure proper cookie deletion. Intercom sets cookies with a domain prefix (e.g. ".domain.com"), and we need to match this 
format when deleting cookies as Chrome/browsers very particular about cookie attributes. 

Key changes:
- Make domain parameter required in both methods
- Ensure domain has a leading dot to match Intercom's cookie format
- Handle localhost domain as a special case
- Update tests to verify correct domain handling
- Improve documentation with clear parameter requirements
- Fix typos in comments

This ensures that Intercom cookies are properly cleared during logout.

Note: This will likely be a major version change if we decide to ship it since it's a breaking change. 